### PR TITLE
gasless deploy wallet only 

### DIFF
--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -28,7 +28,8 @@ import {
   RelayResponse,
   SmartAccountConfig,
   IMetaTransaction,
-  NetworkConfig
+  NetworkConfig,
+  ZERO_ADDRESS
 } from '@biconomy/core-types'
 import { TypedDataSigner } from '@ethersproject/abstract-signer'
 import NodeClient, {
@@ -300,7 +301,7 @@ class SmartAccount extends EventEmitter {
 
     const isDelegate = transaction.to === multiSendContract.address ? true : false
 
-    const response = await aaSigner.sendTransaction(transaction, isDelegate, this)
+    const response = await aaSigner.sendTransaction(transaction, false, isDelegate, this)
 
     return response
     // todo: make sense of this response and return hash to the user
@@ -369,10 +370,15 @@ class SmartAccount extends EventEmitter {
   // Only to deploy wallet using connected paymaster
   // Todo : Add return type
   // Review involvement of Dapp API Key
-  public async deployWalletUsingPaymaster() {
+  public async deployWalletUsingPaymaster(): Promise<TransactionResponse> {
     // can pass chainId
     const aaSigner = this.aaProvider[this.#smartAccountConfig.activeNetworkId].getSigner()
-    await aaSigner.deployWalletOnly()
+    const transaction = {
+      to: ZERO_ADDRESS,
+      data: '0x'
+    }
+    const response = await aaSigner.sendTransaction(transaction, true, false, this)
+    return response
     // Todo: make sense of this response and return hash to the user
   }
 

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -198,9 +198,7 @@ class SmartAccount extends EventEmitter {
       const network = this.chainConfig.find((element: ChainConfig) => element.chainId === chainId)
       if (!network) return
       const providerUrl = this.getProviderUrl(network)
-      console.log('init at chain')
-      console.log(chainId)
-      console.log(providerUrl)
+      console.log('init at chain', chainId)
       const readProvider = new ethers.providers.JsonRpcProvider(providerUrl)
       this.contractUtils.initializeContracts(this.signer, readProvider, network)
 

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -164,10 +164,7 @@ class SmartAccount extends EventEmitter {
   }
 
   getProviderUrl(network: ChainConfig): string {
-    console.log('after init smartAccountConfig.networkConfig')
-    console.log(this.#smartAccountConfig.networkConfig)
     const networkConfig: NetworkConfig[] = this.#smartAccountConfig.networkConfig
-    console.log('networkConfig state is ', networkConfig)
     let providerUrl =
       networkConfig.find((element: NetworkConfig) => element.chainId === network.chainId)
         ?.providerUrl || ''

--- a/packages/transactions/src/ContractUtils.ts
+++ b/packages/transactions/src/ContractUtils.ts
@@ -65,7 +65,6 @@ class ContractUtils {
 
     for (let index = 0; index < smartWallet.length; index++) {
       const version = smartWallet[index].version
-      console.log(smartWallet[index])
 
       this.smartWalletFactoryContract[chaininfo.chainId][version] = getSmartWalletFactoryContract(
         version,


### PR DESCRIPTION


# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Remove deploy wallet only from aa signer and add a flag + ret type in smart account

Fixes # (issue)
SDK demo fails with below if you try to do deployWalletUsingPaymaster and had no return type

```
TransactionNotifier.ts:83 TypeError: Cannot read properties of undefined (reading 'emit')
    at TransactionNotifier.onMined (ERC4337EthersProvider.ts:174:1)
    at TransactionNotifier.transactionNotifierMessageHandler (TransactionNotifier.ts:71:1)
    at Subscription.emit (events.js:153:1)
    at Centrifuge._handlePublication (centrifuge.js:1579:1)
    at Centrifuge._handlePush (centrifuge.js:1596:1)
    at Centrifuge._dispatchReply (centrifuge.js:799:1)
    at centrifuge.js:773:1
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

manual testing from demo apps


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
