### PR TITLE
fix:userop fee values for non eip1559 case

### DIFF
--- a/packages/account-abstraction/src/SmartAccountAPI.ts
+++ b/packages/account-abstraction/src/SmartAccountAPI.ts
@@ -140,6 +140,12 @@ export class SmartAccountAPI extends BaseWalletAPI {
       }
     }
 
+    if(!maxFeePerGas || !maxPriorityFeePerGas) {
+      const gasFee = await this.provider.getGasPrice() // Could be from bundler/ oracle
+      maxFeePerGas = gasFee
+      maxPriorityFeePerGas = gasFee
+    }
+
     const partialUserOp: any = {
       sender: await this.getWalletAddress(),
       nonce: await this.getNonce(0), // TODO (nice-to-have): add batchid as param


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Setting different maxFeePerGas and maxPriorityFeePerGas requires accessing the network's basefee. if you're using a network that doesn't have this opcode, you should set them to the same value.
note that the logic to use with
min(maxFeePerGas, basefee+maxPriorityFeePerGas)
means that base if is effectively ignored if they are the same value.

Fixes # (issue)

## Type of change

for networks that don't support EIP1559 we have to send maxPriorityFeePerGas and maxFeePerGas same

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Undergoing testing with BSC Testnet


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
