### PR TITLE
fix: signTransaction and sendSignedTransaction dto fixes

### DIFF
--- a/packages/core-types/src/SmartAccountTypes.ts
+++ b/packages/core-types/src/SmartAccountTypes.ts
@@ -62,6 +62,7 @@ export type SmartAccountState = {
   fallbackHandlerAddress: string // chain specific?
 }
 
+// Review for optional
 export type AddressForCounterFactualWalletDto = {
   index: number
   chainId: ChainId
@@ -69,9 +70,9 @@ export type AddressForCounterFactualWalletDto = {
 }
 
 export type SignTransactionDto = {
-  version: string
+  version?: string
   tx: IWalletTransaction
-  chainId: ChainId
+  chainId?: ChainId
   signer: Signer
 }
 

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -927,8 +927,8 @@ class SmartAccount extends EventEmitter {
 // Current default config
 // TODO/NOTE : Goerli and Mumbai as test networks and remove others
 export const DefaultSmartAccountConfig: SmartAccountConfig = {
-  activeNetworkId: ChainId.GOERLI, //Update later
-  supportedNetworksIds: [ChainId.GOERLI, ChainId.POLYGON_MUMBAI, ChainId.POLYGON_MAINNET],
+  activeNetworkId: ChainId.POLYGON_MUMBAI, //Update later
+  supportedNetworksIds: [ChainId.GOERLI, ChainId.POLYGON_MUMBAI, ChainId.POLYGON_MAINNET, ChainId.BSC_TESTNET],
   signType: SignTypeMethod.EIP712_SIGN,
   backendUrl: 'https://sdk-backend.prod.biconomy.io/v1',
   relayerUrl: 'https://sdk-relayer.prod.biconomy.io/api/v1/relay',

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -652,6 +652,7 @@ class SmartAccount extends EventEmitter {
     if (gasLimit) {
       relayTrx.gasLimit = gasLimit
     }
+    // todo : review gasLimit passed to relay endpoint
     if (!isDeployed) {
       gasLimit = {
         hex: '0x1E8480',


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

signTransactionDto requires mandatory version and chainId which should be ideally optional
sendSignedTransaction method expects gasLimit which is optional, but if not passed then relay endpoint fails 

Fixes # (issue)

update dto type
update default gas limit / omit

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

with demo dapps

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
