### PR TITLE
fix: css file not found

### DIFF
--- a/packages/web3-auth/package.json
+++ b/packages/web3-auth/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build": "rimraf dist && tsc",
+    "copy-files": "npx copyfiles -u 1 src/**/*.css dist/src",
+    "build": "rimraf dist && tsc && yarn copy-files",
     "format": "prettier --write \"{src,tests}/**/*.ts\"",
     "lint": "tslint -p tsconfig.json"
   },


### PR DESCRIPTION
# Description

Etenstion of https://github.com/bcnmy/biconomy-client-sdk/pull/82 

Fixes # (issue)
#75 

## Breaking change
CSS file has been separated and developers have to import the css in top level file now.
```ts
import "@biconomy/web3-auth/src/style.css"
```

