### PR TITLE
fix:make gas limit really optional

### DIFF
--- a/packages/relayer/src/LocalRelayer.ts
+++ b/packages/relayer/src/LocalRelayer.ts
@@ -6,7 +6,8 @@ import {
   DeployWallet,
   FeeOptionsResponse,
   RelayTransaction,
-  RelayResponse
+  RelayResponse,
+  GasLimit
 } from '@biconomy/core-types'
 import { MetaTransaction, encodeMultiSend } from './utils/MultiSend'
 
@@ -59,7 +60,7 @@ export class LocalRelayer implements IRelayer {
   }
 
   async relay(relayTransaction: RelayTransaction): Promise<RelayResponse> {
-    const { config, signedTx, context } = relayTransaction
+    const { config, signedTx, context, gasLimit } = relayTransaction
     const { isDeployed, address } = config
     const { multiSendCall } = context // multisend has to be multiSendCallOnly here!
     if (!isDeployed) {
@@ -98,7 +99,7 @@ export class LocalRelayer implements IRelayer {
 
       const tx = this.signer.sendTransaction({
         ...finalRawRx,
-        gasLimit: ethers.constants.Two.pow(24)
+        gasLimit: gasLimit ? (gasLimit as GasLimit).hex : ethers.constants.Two.pow(24)
       })
       return tx
       // rawTx to becomes multiSend address and data gets prepared again
@@ -106,7 +107,7 @@ export class LocalRelayer implements IRelayer {
 
     const tx = this.signer.sendTransaction({
       ...signedTx.rawTx,
-      gasLimit: ethers.constants.Two.pow(24)
+      gasLimit: gasLimit ? (gasLimit as GasLimit).hex : ethers.constants.Two.pow(24)
     })
     return tx
   }

--- a/packages/relayer/src/RestRelayer.ts
+++ b/packages/relayer/src/RestRelayer.ts
@@ -146,7 +146,8 @@ export class RestRelayer implements IRelayer {
         params: [
           {
             ...finalRawRx,
-            gasLimit: (gasLimit as GasLimit).hex,
+            // Could send custom high instead of undefined
+            gasLimit: gasLimit ? (gasLimit as GasLimit).hex : undefined,
             walletInfo: {
               address: address
             },
@@ -161,8 +162,6 @@ export class RestRelayer implements IRelayer {
       }
     })
 
-    console.log('rest relayer : response')
-    console.log(response)
     if (response.data) {
       const transactionId = response.data.transactionId
       const connectionUrl = response.data.connectionUrl

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -604,8 +604,6 @@ class SmartAccount extends EventEmitter {
       relayTrx.gasLimit = gasLimit
     }
     const relayResponse: RelayResponse = await this.relayer.relay(relayTrx, this)
-    console.log('relayResponse')
-    console.log(relayResponse)
     if (relayResponse.transactionId) {
       return relayResponse.transactionId
     }

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -307,7 +307,7 @@ class SmartAccount extends EventEmitter {
   // Optional methods for connecting paymaster
   // Optional methods for connecting another bundler
 
-  public async sendGasLessTransaction(
+  public async sendGaslessTransaction(
     transactionDto: TransactionDto
   ): Promise<TransactionResponse> {
     let { version, chainId } = transactionDto
@@ -383,7 +383,7 @@ class SmartAccount extends EventEmitter {
     // Multisend is tricky because populateTransaction expects delegateCall and we must override
 
     // TODO : stuff before this can be moved to TransactionManager
-    const response = await this.sendGasLessTransaction({ version, transaction: gaslessTx, chainId })
+    const response = await this.sendGaslessTransaction({ version, transaction: gaslessTx, chainId })
     return response
   }
 


### PR DESCRIPTION
# Description

smartAccount.sendTransaction accepts SendTransactionDto and dispatches to relayer.relay which accepts RelayTransactionDto. GasLimit is optional in both of these Dtos but within RestRelayer.relay it passed on gasLimit.hex whatsoever. This PR fixes above bug that broke the code

Fixes # (issue)

## Type of change

Fixture in making gasLimit truly optional

Testing Notes: 

gasLimit truly optional for sendTransaction.  after changes : if I don’t provide custom gas limit it works but internal ten fails with BSA010   require(gasleft() >= max((_tx.targetTxGas * 64) / 63,_tx.targetTxGas + 2500) + 500, "BSA010");
 This is because of gasLimit calculated in relayer and targetTxGas estimated and sent!  failed without custom gasLimit - https://mumbai.polygonscan.com/tx/0xaee78c4d6b5d340d00292d01c546cfbeabf3fe370664e6776150916d78cf45bb

Success with custom gasLimit - https://mumbai.polygonscan.com/tx/0x22e9842a690aa4862ab90cc96659ffc4412603e8fb618681741595509a63e9e9


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

using sdk-demo Dapp


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
