### PR TITLE
fix: tx receipt from messaging sdk + dev notes

### DIFF
--- a/packages/account-abstraction/src/ERC4337EthersProvider.ts
+++ b/packages/account-abstraction/src/ERC4337EthersProvider.ts
@@ -171,7 +171,6 @@ export class ERC4337EthersProvider extends BaseProvider {
               })}`
             )
             const receipt: TransactionReceipt = tx.receipt
-            // Todo // review below
             engine.emit('txMined', {
               msg: 'txn mined',
               id: txId,

--- a/packages/account-abstraction/src/ERC4337EthersProvider.ts
+++ b/packages/account-abstraction/src/ERC4337EthersProvider.ts
@@ -170,7 +170,10 @@ export class ERC4337EthersProvider extends BaseProvider {
                 receipt: tx.receipt
               })}`
             )
+            tx.receipt.transactionHash = tx.receipt.hash
+            delete tx.receipt.hash
             const receipt: TransactionReceipt = tx.receipt
+            // Todo // review below
             engine.emit('txMined', {
               msg: 'txn mined',
               id: txId,
@@ -198,7 +201,7 @@ export class ERC4337EthersProvider extends BaseProvider {
       wait: async (confirmations?: number): Promise<TransactionReceipt> => {
         console.log(confirmations)
         const transactionReceipt = waitPromise.then((receipt: any) => {
-          console.log('received tx receipt ', transactionReceipt)
+          console.log('received tx receipt ', receipt)
           return receipt
         })
         if (userOp.initCode.length !== 0) {

--- a/packages/account-abstraction/src/ERC4337EthersProvider.ts
+++ b/packages/account-abstraction/src/ERC4337EthersProvider.ts
@@ -170,8 +170,6 @@ export class ERC4337EthersProvider extends BaseProvider {
                 receipt: tx.receipt
               })}`
             )
-            tx.receipt.transactionHash = tx.receipt.hash
-            delete tx.receipt.hash
             const receipt: TransactionReceipt = tx.receipt
             // Todo // review below
             engine.emit('txMined', {
@@ -200,8 +198,8 @@ export class ERC4337EthersProvider extends BaseProvider {
       chainId: this.config.chainId,
       wait: async (confirmations?: number): Promise<TransactionReceipt> => {
         console.log(confirmations)
-        const transactionReceipt = waitPromise.then((receipt: any) => {
-          console.log('received tx receipt ', receipt)
+        const transactionReceipt = waitPromise.then((receipt: TransactionReceipt) => {
+          // console.log('received tx receipt ', receipt)
           return receipt
         })
         if (userOp.initCode.length !== 0) {


### PR DESCRIPTION
# Description

For dispatching AA transaction on chain via bundler, ERC4337Provider [constructs](https://github.com/bcnmy/biconomy-client-sdk/blob/master/packages/account-abstraction/src/ERC4337EthersProvider.ts#L163) a response (type TransactionResponse) 
[ Note: The hash you get from txResponse is not the transaction hash but requestId ] 
For above response, wait() is supposed to return receipt Promise<TransactionReceipt> in which transaction hash must be transactionHash. Currently it is captured in receipt.hash hence on the client side type any has to be used and by capturing receipt.hash which is wrong. This change fixes types in receipt and makes it transactionHash...

Further notes : WIP to get recept.transactionHash from upstream (which is messaging sdk / transaction listener service.) cc @kunal047 to get status as well for the receipt. we should not declare our own types 

# References of types

TransactionResponse

`export interface Transaction {
    hash?: string;

    to?: string;
    from?: string;
    nonce: number;

    gasLimit: BigNumber;
    gasPrice?: BigNumber;

    data: string;
    value: BigNumber;
    chainId: number;

    r?: string;
    s?: string;
    v?: number;

    // Typed-Transaction features
    type?: number | null;

    // EIP-2930; Type 1 & EIP-1559; Type 2
    accessList?: AccessList;

    // EIP-1559; Type 2
    maxPriorityFeePerGas?: BigNumber;
    maxFeePerGas?: BigNumber;
}



export interface TransactionResponse extends Transaction {
    hash: string;

    // Only if a transaction has been mined
    blockNumber?: number,
    blockHash?: string,
    timestamp?: number,

    confirmations: number,

    // Not optional (as it is in Transaction)
    from: string;

    // The raw transaction
    raw?: string,

    // This function waits until the transaction has been mined
    wait: (confirmations?: number) => Promise<TransactionReceipt>
};`



Fixes # (issue)

## Type of change

Make transaction receipt from onMined event ( for txResponse.wait() ) compatible with TransactionReceipt type from ethers. 


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

in demo dapp

`import { TransactionReceipt } from '@ethersproject/providers'
const txResponse = await smartAccount.sendGaslessTransactionBatch({ transactions: txs });
      console.log("txResponse", txResponse);
      if(txResponse) {
      
        let receipt: TransactionReceipt = await txResponse.wait(2);
        let txn: Transaction = {
          state: "Pending",
          txHash: receipt.transactionHash,
          explorerLink: `[https://mumbai.polygonscan.com/tx/${receipt.transactionHash}](https://mumbai.polygonscan.com/tx/$%7Breceipt.transactionHash%7D)`
        }
        transactions.push(txn);
        setTransactions(transactions);
        console.log("Receipt: ", receipt);
        if(smartAccountAddress) {
          getTokenBalances(smartAccountAddress);
        }
      }`
      
TransactionReceipt (ethers js)

`export interface TransactionReceipt {
    to: string;
    from: string;
    contractAddress: string,
    transactionIndex: number,
    root?: string,
    gasUsed: BigNumber,
    logsBloom: string,
    blockHash: string,
    transactionHash: string,
    logs: Array<Log>,
    blockNumber: number,
    confirmations: number,
    cumulativeGasUsed: BigNumber,
    effectiveGasPrice: BigNumber,
    byzantium: boolean,
    type: number;
    status?: number
};`

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
