### PR TITLE
Signing service negative case (allow wallet self sponsor)

### DIFF
--- a/packages/account-abstraction/src/ClientConfig.ts
+++ b/packages/account-abstraction/src/ClientConfig.ts
@@ -9,5 +9,6 @@ export interface ClientConfig {
   bundlerUrl: string
   chainId: number
   txServiceUrl: string
+  strictSponsorshipMode?: boolean // review
   // not using accountAddress in client config
 }

--- a/packages/core-types/src/AccountAbstractionTypes.ts
+++ b/packages/core-types/src/AccountAbstractionTypes.ts
@@ -4,6 +4,14 @@ export interface IPaymasterAPI {
   getPaymasterAndData(userOp: Partial<UserOperation>): Promise<string>
 }
 
+export type PaymasterConfig = {
+  signingServiceUrl: string
+  dappAPIKey: string
+  strictSponsorshipMode: boolean
+}
+
 export interface IFallbackAPI {
   getDappIdentifierAndSign(userOp: Partial<UserOperation>): Promise<FallbackApiResponse>
 }
+
+

--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -260,6 +260,9 @@ class SmartAccount extends EventEmitter {
         new ethers.providers.JsonRpcProvider(providerUrl),
         {
           dappAPIKey: clientConfig.dappAPIKey || '',
+          // Review: default false
+          // could come from global set config or method level when we implement fee mode
+          strictSponsorshipMode: false,
           biconomySigningServiceUrl: this.#smartAccountConfig.biconomySigningServiceUrl || '',
           socketServerUrl: this.#smartAccountConfig.socketServerUrl || '',
           entryPointAddress: this.#smartAccountConfig.entryPointAddress


### PR DESCRIPTION
feat/strictSponsorshipMode and fix/BiconomyPaymasterAPI edge case + dev notes + update type

# Description

* added strictSponsorshipMode field in ClientConfig
* made constructor of BiconomyPaymasterAPI to just take one argument as object
* based on strictSponsorshipMode (default value currently false and dapps can't pass) and if signingService fails we will return '0x' so the wallet can self sponsor
* if account still doesnt have funds it should fail from bundler service with proper error code / message
[ signing service never returns other statusCode than 200 or message and always throws which is something we can look into @arcticfloyd1984  @talhamalik883 ] 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
