### PR TITLE
fix invalid v value in userop signature

### DIFF
--- a/packages/smart-account/src/SmartAccount.ts
+++ b/packages/smart-account/src/SmartAccount.ts
@@ -679,6 +679,12 @@ class SmartAccount extends EventEmitter {
       const { data } = await smartAccountSignTypedData(this.signer, walletContract, tx, chainId)
       signature += data.slice(2)
     }
+    const potentiallyIncorrectV = parseInt(signature.slice(-2), 16)
+    if (![27, 28].includes(potentiallyIncorrectV)) {
+      const correctV = potentiallyIncorrectV + 27
+      signature = signature.slice(0, -2) + correctV.toString(16)
+    }
+    Logger.log('non-4337 flow signature: ', signature)
     return signature
   }
 


### PR DESCRIPTION
# Description

Hardware wallet like ledger or MPC wallet signers like Portal sends v value 0 or 1 in signature. This fixes v value to be either 27 or 28 (1b or 1c)
Also checks if signature doesn't start with 0x then append 0x.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
