### PR TITLE
verify account deployment even when nonce is 0

### DIFF
--- a/packages/account/src/BiconomySmartAccount.ts
+++ b/packages/account/src/BiconomySmartAccount.ts
@@ -288,10 +288,14 @@ export class BiconomySmartAccount extends SmartAccount implements IBiconomySmart
     } catch (error) {
       // Not throwing this error as nonce would be 0 if this.nonce() throw exception, which is expected flow for undeployed account
     }
+    let isDeployed = true
+
+    isDeployed = nonce.eq(0) ? await this.isAccountDeployed(this.address) : true
+ 
     let userOp: Partial<UserOperation> = {
       sender: this.address,
       nonce,
-      initCode: nonce.eq(0) ? this.initCode : '0x',
+      initCode: !isDeployed ? this.initCode : '0x',
       callData: callData
     }
 

--- a/packages/account/src/BiconomySmartAccount.ts
+++ b/packages/account/src/BiconomySmartAccount.ts
@@ -290,8 +290,10 @@ export class BiconomySmartAccount extends SmartAccount implements IBiconomySmart
     }
     let isDeployed = true
 
-    isDeployed = nonce.eq(0) ? await this.isAccountDeployed(this.address) : true
- 
+    if (nonce.eq(0)) {
+      isDeployed = await this.isAccountDeployed(this.address)
+    }
+
     let userOp: Partial<UserOperation> = {
       sender: this.address,
       nonce,


### PR DESCRIPTION
An RPC call is made to verify whether the smart account is deployed when the nonce is zero. We previously implemented logic to include initCode in userOp only when the nonce is zero. However, we discovered a scenario where someone might have deployed the smart account on your behalf, resulting in a nonce of zero. In this case, the initCode should not be added to userOp.