### PR TITLE
attach signer function call

### DIFF
--- a/packages/account/src/BiconomySmartAccount.ts
+++ b/packages/account/src/BiconomySmartAccount.ts
@@ -37,6 +37,7 @@ import {
   BICONOMY_IMPLEMENTATION_ADDRESSES,
   DEFAULT_ENTRYPOINT_ADDRESS
 } from './utils/Constants'
+import { Signer } from 'ethers'
 
 export class BiconomySmartAccount extends SmartAccount implements IBiconomySmartAccount {
   private factory!: SmartAccountFactory_v100
@@ -101,6 +102,15 @@ export class BiconomySmartAccount extends SmartAccount implements IBiconomySmart
     }
 
     return this
+  }
+
+  async attachSigner(_signer: Signer): Promise<void> {
+    try {
+      this.signer = _signer
+      this.owner = await this.signer.getAddress()
+    } catch (error) {
+      throw new Error(`Failed to get signer address`)
+    }
   }
 
   private isInitialized(): boolean {

--- a/packages/account/src/interfaces/IBiconomySmartAccount.ts
+++ b/packages/account/src/interfaces/IBiconomySmartAccount.ts
@@ -11,6 +11,7 @@ import {
 import { Overrides, InitilizationData } from '../utils/Types'
 import { BigNumberish, BytesLike } from 'ethers'
 import { ISmartAccount } from './ISmartAccount'
+import { Signer } from 'ethers'
 
 export interface IBiconomySmartAccount extends ISmartAccount {
   init(initilizationData?: InitilizationData): Promise<this>
@@ -30,4 +31,5 @@ export interface IBiconomySmartAccount extends ISmartAccount {
   getTransactionsByAddress(chainId: number, address: string): Promise<SCWTransactionResponse[]>
   getTransactionByHash(txHash: string): Promise<SCWTransactionResponse>
   getAllSupportedChains(): Promise<SupportedChainsResponse>
+  attachSigner(signer: Signer): Promise<void>
 }


### PR DESCRIPTION
# Description

BiconomySmartAccount class exposed a new function called "attachSigner," which enables developers to associate a signer at a later point before signing userOp. 

When constructing userOps, developers can initially provide a VoidSigner instance with an identical address to the original signer. However, prior to userOp signing, it is necessary to provide the proper signer by using the "attachSigner" function.





Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
