### PR TITLE
use proof instead of root in signUserOpHash

### DIFF
--- a/packages/modules/src/SessionKeyManagerModule.ts
+++ b/packages/modules/src/SessionKeyManagerModule.ts
@@ -142,6 +142,15 @@ export class SessionKeyManagerModule extends BaseValidationModule {
       throw new Error('sessionID or sessionValidationModule should be provided.')
     }
 
+    const leafDataHex = ethers.utils.keccak256(
+      hexConcat([
+        sessionSignerData.validUntil,
+        sessionSignerData.validAfter,
+        sessionSignerData.sessionValidationModule,
+        sessionSignerData.sessionKeyData,
+      ])
+    )
+
     // Generate the padded signature with (validUntil,validAfter,sessionVerificationModuleAddress,validationData,merkleProof,signature)
     let paddedSignature = defaultAbiCoder.encode(
       ['uint48', 'uint48', 'address', 'bytes', 'bytes32[]', 'bytes'],
@@ -150,7 +159,7 @@ export class SessionKeyManagerModule extends BaseValidationModule {
         sessionSignerData.validAfter,
         sessionSignerData.sessionValidationModule,
         sessionSignerData.sessionKeyData,
-        this.merkleTree.getHexRoot(),
+        this.merkleTree.getHexProof(leafDataHex),
         signature
       ]
     )

--- a/packages/modules/src/SessionKeyManagerModule.ts
+++ b/packages/modules/src/SessionKeyManagerModule.ts
@@ -142,14 +142,12 @@ export class SessionKeyManagerModule extends BaseValidationModule {
       throw new Error('sessionID or sessionValidationModule should be provided.')
     }
 
-    const leafDataHex = ethers.utils.keccak256(
-      hexConcat([
-        sessionSignerData.validUntil,
-        sessionSignerData.validAfter,
-        sessionSignerData.sessionValidationModule,
-        sessionSignerData.sessionKeyData,
-      ])
-    )
+    const leafDataHex = hexConcat([
+      hexZeroPad(ethers.utils.hexlify(sessionSignerData.validUntil), 6),
+      hexZeroPad(ethers.utils.hexlify(sessionSignerData.validAfter), 6),
+      hexZeroPad(sessionSignerData.sessionValidationModule, 20),
+      sessionSignerData.sessionKeyData
+    ])
 
     // Generate the padded signature with (validUntil,validAfter,sessionVerificationModuleAddress,validationData,merkleProof,signature)
     let paddedSignature = defaultAbiCoder.encode(
@@ -159,7 +157,7 @@ export class SessionKeyManagerModule extends BaseValidationModule {
         sessionSignerData.validAfter,
         sessionSignerData.sessionValidationModule,
         sessionSignerData.sessionKeyData,
-        this.merkleTree.getHexProof(leafDataHex),
+        this.merkleTree.getHexProof(ethers.utils.keccak256(leafDataHex)),
         signature
       ]
     )


### PR DESCRIPTION
# Description

As per https://github.com/bcnmy/scw-contracts/blob/SCW-V2-Modular-SA/contracts/smart-account/modules/SessionKeyManagerModule.sol#L79-L86 merkleProof should be getHexProof of keccack256 of leaf

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

not test extensively, just matched specs with contract


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
