### PR TITLE
Set merkle root in session storage while creating session

### DIFF
--- a/packages/modules/src/SessionKeyManagerModule.ts
+++ b/packages/modules/src/SessionKeyManagerModule.ts
@@ -113,6 +113,7 @@ export class SessionKeyManagerModule extends BaseValidationModule {
     }
 
     await this.sessionStorageClient.addSessionData(sessionLeafNode)
+    await this.sessionStorageClient.setMerkleRoot(this.merkleTree.getHexRoot())
     // TODO: create a signer if sessionPubKey if not given
     return setMerkleRootData
   }

--- a/packages/modules/src/interfaces/ISessionStorage.ts
+++ b/packages/modules/src/interfaces/ISessionStorage.ts
@@ -74,4 +74,10 @@ export interface ISessionStorage {
    * Fetch merkle root from the session storage
    */
   getMerkleRoot(): Promise<string>
+
+  /**
+   * Set merkle root in the session storage
+   * @param merkleRoot Merkle root to be set in the session storage
+   */
+  setMerkleRoot(merkleRoot: string): Promise<void>
 }

--- a/packages/modules/src/session-storage/SessionLocalStorage.ts
+++ b/packages/modules/src/session-storage/SessionLocalStorage.ts
@@ -145,4 +145,11 @@ export class SessionLocalStorage implements ISessionStorage {
   async getMerkleRoot(): Promise<string> {
     return this.getSessionStore().merkleRoot
   }
+
+  setMerkleRoot(merkleRoot: string): Promise<void> {
+    const data = this.getSessionStore()
+    data.merkleRoot = merkleRoot
+    localStorage.setItem(this.getStorageKey('sessions'), JSON.stringify(data))
+    return Promise.resolve()
+  }
 }


### PR DESCRIPTION
Adding merkle root in session storage when a new session is created and stored in the storage.