### PR TITLE
buildUserOp: force encode for batch

### DIFF
--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -312,12 +312,18 @@ export class BiconomySmartAccountV2 extends BaseSmartAccount {
     const data = transactions.map((element: Transaction) => element.data ?? '0x')
     const value = transactions.map((element: Transaction) => element.value ?? BigNumber.from('0'))
 
-    let callData = ''
-    if (transactions.length === 1) {
-      callData = await this.encodeExecute(to[0], value[0], data[0])
-    } else {
-      callData = await this.encodeExecuteBatch(to, value, data)
+    if (transactions.length === 0) {
+      throw new Error('Transactions array cannot be empty')
     }
+
+    let callData = ''
+    if (transactions.length > 1 || buildUseropDto?.forceEncodeForBatch) {
+      callData = await this.encodeExecuteBatch(to, value, data)
+    } else {
+      // transactions.length must be 1
+      callData = await this.encodeExecute(to[0], value[0], data[0])
+    }
+
     let nonce = BigNumber.from(0)
     try {
       nonce = await this.getNonce()

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -76,6 +76,7 @@ export type BuildUserOpOptions = {
   overrides?: Overrides
   skipBundlerGasEstimation?: boolean
   params?: ModuleInfo
+  forceEncodeForBatch?: boolean
 }
 
 export type Overrides = {


### PR DESCRIPTION
# Description

in buildUserOp even if transactions array length is 1, for some validation modules optionally devs want to encode it for executeBatch. optional flag is added which achieves this

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
