### PR TITLE
fix: gitInitCode cache issue

### DIFF
--- a/packages/account/src/BaseSmartAccount.ts
+++ b/packages/account/src/BaseSmartAccount.ts
@@ -18,8 +18,6 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
   // Review : compare with BaseAccountAPI
   // private senderAddress!: string
 
-  private isDeployed = false;
-
   bundler?: IBundler; // httpRpcClient
 
   paymaster?: IPaymaster; // paymasterAPI
@@ -61,14 +59,6 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
       throw new Error(`EntryPoint not deployed at ${this.entryPointAddress} at chainId ${this.chainId}}`);
     }
 
-    // Note: Review
-    // on Init itself since we're already getting account address, mark isDeployed as well!
-
-    if ((await this.provider.getCode(await this.getAccountAddress())) === "0x") {
-      this.isDeployed = false;
-    } else {
-      this.isDeployed = true;
-    }
     return this;
   }
 
@@ -298,17 +288,14 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
   // Review : usage trace of this method. in the order of init and methods called on the Account
   async isAccountDeployed(address: string): Promise<boolean> {
     this.isProviderDefined();
-    if (this.isDeployed !== undefined || this.isDeployed !== null) {
-      // already deployed. no need to check anymore.
-      return this.isDeployed;
-    }
+    let isDeployed = false;
     const contractCode = await this.provider.getCode(address);
     if (contractCode.length > 2) {
-      this.isDeployed = true;
+      isDeployed = true;
     } else {
-      this.isDeployed = false;
+      isDeployed = false;
     }
-    return this.isDeployed;
+    return isDeployed;
   }
 
   /**

--- a/packages/account/tests/SmartAccountV2.local.spec.ts
+++ b/packages/account/tests/SmartAccountV2.local.spec.ts
@@ -12,7 +12,6 @@ import {
 } from "@biconomy/common";
 
 import { BiconomySmartAccountV2 } from "../src/BiconomySmartAccountV2";
-import { BiconomySmartAccount } from "../src/BiconomySmartAccount";
 import { ChainId, UserOperation } from "@biconomy/core-types";
 import { DEFAULT_ECDSA_OWNERSHIP_MODULE, ECDSAOwnershipValidationModule } from "@biconomy/modules";
 import { MultiChainValidationModule } from "@biconomy/modules";
@@ -163,9 +162,7 @@ describe("BiconomySmartAccountV2 API Specs", () => {
     // Review: Just setting different default validation module and querying account address is not working
     // accountAPI.setDefaultValidationModule(module2);
 
-    // accountAPI.setActiveValidationModule(module2);
-
-    // Review
+    // Review with setting different validation module other than provided in config
     accountAPI2 = await accountAPI2.init();
 
     const accountAddress2 = await accountAPI2.getAccountAddress();
@@ -221,23 +218,10 @@ describe("BiconomySmartAccountV2 API Specs", () => {
       value: ethers.utils.parseEther("0.1"),
     });
 
-    console.log("accountAPI.accountAddress", accountAPI.accountAddress);
-
-    // TODO
-    // Note: this is a MUST currently otherwise account deployed state does not get updated and returns wrong initcode
-    accountAPI = await accountAPI.init();
-
-    /*const initCode = await accountAPI.getInitCode();
-    console.log("initCode ", initCode);
-
-    console.log("isDeployed", accountAPI.isAccountDeployed(accountAddress));*/
-
     const op = await accountAPI.buildUserOp([enableModuleData], {
       // skipBundlerGasEstimation: true,
       // overrides: { verificationGasLimit: 120000, callGasLimit: 100000, preVerificationGas: 60000 },
     });
-
-    console.log("op ", op);
 
     const signedUserOp = await accountAPI.signUserOp(op);
 


### PR DESCRIPTION
The BaseSmartAccount has isDeployed variable in cache, and it stores it on constructor init as default false then read.

It is never updated, so either can updated but in other methods but then will have to add logic if tx is failed or not.

Best way is to remove this check and call rpc to check if deployed or not everytime