### PR TITLE
Feat/devx 336 abstract paymaster

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
     ]
   },
   "dependencies": {
+    "dotenv": "^16.3.1",
     "node-gyp": "^9.4.0",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "ganache": "^7.9.1",
     "@types/debug": "^4.1.9",
     "@types/jest": "^29.5.4",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -68,6 +68,7 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-security": "^1.7.1",
+    "ganache": "^7.9.1",
     "hardhat": "^2.17.3",
     "jest": "^29.7.0",
     "lerna": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     ]
   },
   "dependencies": {
-    "dotenv": "^16.3.1",
     "node-gyp": "^9.4.0",
     "typescript": "^5.2.2"
   },

--- a/packages/account/src/BaseSmartAccount.ts
+++ b/packages/account/src/BaseSmartAccount.ts
@@ -52,12 +52,6 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
 
     this.provider = _smartAccountConfig.provider ?? new JsonRpcProvider(RPC_PROVIDER_URLS[this.chainId]);
 
-    if (_smartAccountConfig.apiKey) {
-      this.paymaster = new BiconomyPaymaster({
-        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${_smartAccountConfig.chainId}/${_smartAccountConfig.apiKey}`,
-      });
-    }
-
     // Create an instance of the EntryPoint contract using the provided address and provider (facory "connect" contract address)
     // Then, set the transaction's sender ("from" address) to the zero address (AddressZero). (contract "connect" from address)
     this.entryPoint = EntryPoint__factory.connect(this.entryPointAddress, this.provider).connect(ethers.constants.AddressZero);

--- a/packages/account/src/BaseSmartAccount.ts
+++ b/packages/account/src/BaseSmartAccount.ts
@@ -52,8 +52,10 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
 
     this.provider = _smartAccountConfig.provider ?? new JsonRpcProvider(RPC_PROVIDER_URLS[this.chainId]);
 
-    if(_smartAccountConfig.apiKey) {
-      this.paymaster = new BiconomyPaymaster({paymasterUrl: `https://paymaster.biconomy.io/api/v1/${_smartAccountConfig.chainId}/${_smartAccountConfig.apiKey}`});
+    if (_smartAccountConfig.apiKey) {
+      this.paymaster = new BiconomyPaymaster({
+        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${_smartAccountConfig.chainId}/${_smartAccountConfig.apiKey}`,
+      });
     }
 
     // Create an instance of the EntryPoint contract using the provided address and provider (facory "connect" contract address)

--- a/packages/account/src/BaseSmartAccount.ts
+++ b/packages/account/src/BaseSmartAccount.ts
@@ -47,11 +47,14 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
     this.overheads = _smartAccountConfig.overheads;
     this.entryPointAddress = _smartAccountConfig.entryPointAddress ?? DEFAULT_ENTRYPOINT_ADDRESS;
     this.accountAddress = _smartAccountConfig.accountAddress;
-    this.paymaster = _smartAccountConfig.paymaster;
     this.bundler = _smartAccountConfig.bundler;
     this.chainId = _smartAccountConfig.chainId;
 
     this.provider = _smartAccountConfig.provider ?? new JsonRpcProvider(RPC_PROVIDER_URLS[this.chainId]);
+
+    if(_smartAccountConfig.apiKey) {
+      this.paymaster = new BiconomyPaymaster({paymasterUrl: `https://paymaster.biconomy.io/api/v1/${_smartAccountConfig.chainId}/${_smartAccountConfig.apiKey}`});
+    }
 
     // Create an instance of the EntryPoint contract using the provided address and provider (facory "connect" contract address)
     // Then, set the transaction's sender ("from" address) to the zero address (AddressZero). (contract "connect" from address)

--- a/packages/account/src/BaseSmartAccount.ts
+++ b/packages/account/src/BaseSmartAccount.ts
@@ -50,6 +50,10 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
     this.bundler = _smartAccountConfig.bundler;
     this.chainId = _smartAccountConfig.chainId;
 
+    if (_smartAccountConfig.paymaster) {
+      this.paymaster = _smartAccountConfig.paymaster;
+    }
+
     this.provider = _smartAccountConfig.provider ?? new JsonRpcProvider(RPC_PROVIDER_URLS[this.chainId]);
 
     // Create an instance of the EntryPoint contract using the provided address and provider (facory "connect" contract address)

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -84,9 +84,9 @@ export class BiconomySmartAccountV2 extends BaseSmartAccount {
     const instance = new BiconomySmartAccountV2(biconomySmartAccountConfig);
     instance.factoryAddress = biconomySmartAccountConfig.factoryAddress ?? DEFAULT_BICONOMY_FACTORY_ADDRESS; // This would be fetched from V2
 
-    if (biconomySmartAccountConfig.apiKey) {
+    if (biconomySmartAccountConfig.biconomyPaymasterApiKey) {
       instance.paymaster = new BiconomyPaymaster({
-        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${biconomySmartAccountConfig.chainId}/${biconomySmartAccountConfig.apiKey}`,
+        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${biconomySmartAccountConfig.chainId}/${biconomySmartAccountConfig.biconomyPaymasterApiKey}`,
       });
     }
 

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -84,6 +84,12 @@ export class BiconomySmartAccountV2 extends BaseSmartAccount {
     const instance = new BiconomySmartAccountV2(biconomySmartAccountConfig);
     instance.factoryAddress = biconomySmartAccountConfig.factoryAddress ?? DEFAULT_BICONOMY_FACTORY_ADDRESS; // This would be fetched from V2
 
+    if (biconomySmartAccountConfig.apiKey) {
+      instance.paymaster = new BiconomyPaymaster({
+        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${biconomySmartAccountConfig.chainId}/${biconomySmartAccountConfig.apiKey}`,
+      });
+    }
+
     const defaultFallbackHandlerAddress =
       instance.factoryAddress === DEFAULT_BICONOMY_FACTORY_ADDRESS
         ? DEFAULT_FALLBACK_HANDLER_ADDRESS

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -44,6 +44,7 @@ export interface BaseSmartAccountConfig {
   accountAddress?: string;
   overheads?: Partial<GasOverheads>;
   paymaster?: IPaymaster; // PaymasterAPI
+  apiKey?: string;  
   bundler?: IBundler; // like HttpRpcClient
   chainId: ChainId;
 }

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -44,7 +44,6 @@ export interface BaseSmartAccountConfig {
   accountAddress?: string;
   overheads?: Partial<GasOverheads>;
   paymaster?: IPaymaster; // PaymasterAPI
-  apiKey?: string;
   bundler?: IBundler; // like HttpRpcClient
   chainId: ChainId;
 }
@@ -70,6 +69,7 @@ export interface BiconomySmartAccountV2Config extends BaseSmartAccountConfig {
   senderAddress?: string;
   implementationAddress?: string;
   defaultFallbackHandler?: string;
+  apiKey?: string;
   rpcUrl?: string; // as good as Provider
   nodeClientUrl?: string; // very specific to Biconomy
   defaultValidationModule: BaseValidationModule;

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -69,7 +69,7 @@ export interface BiconomySmartAccountV2Config extends BaseSmartAccountConfig {
   senderAddress?: string;
   implementationAddress?: string;
   defaultFallbackHandler?: string;
-  apiKey?: string;
+  biconomyPaymasterApiKey?: string;
   rpcUrl?: string; // as good as Provider
   nodeClientUrl?: string; // very specific to Biconomy
   defaultValidationModule: BaseValidationModule;

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -44,7 +44,7 @@ export interface BaseSmartAccountConfig {
   accountAddress?: string;
   overheads?: Partial<GasOverheads>;
   paymaster?: IPaymaster; // PaymasterAPI
-  apiKey?: string;  
+  apiKey?: string;
   bundler?: IBundler; // like HttpRpcClient
   chainId: ChainId;
 }

--- a/packages/account/tests/SmartAccountV2-Abstract-Paymaster.local.spec.ts
+++ b/packages/account/tests/SmartAccountV2-Abstract-Paymaster.local.spec.ts
@@ -16,8 +16,6 @@ import { BaseValidationModule } from "@biconomy/modules";
 import { ECDSAOwnershipRegistryModule_v100 } from "@biconomy/common";
 import { BiconomyPaymaster } from "@biconomy/paymaster";
 
-require('dotenv').config();
-
 const provider = new ethers.providers.JsonRpcProvider("http://127.0.0.1:8545");
 const signer = provider.getSigner();
 
@@ -59,7 +57,7 @@ describe("BiconomySmartAccountV2 Paymaster Abstraction", () => {
       chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
-      biconomyPaymasterApiKey: process.env.API_KEY,
+      biconomyPaymasterApiKey: "7K_k68BFN.ed274da8-69a1-496d-a897-508fc2213216",
       factoryAddress: accountFactory.address,
       defaultFallbackHandler: await accountFactory.minimalHandler(),
       defaultValidationModule: module1,
@@ -80,7 +78,7 @@ describe("BiconomySmartAccountV2 Paymaster Abstraction", () => {
   it("Create a smart account with paymaster by creating instance", async () => {
 
     const paymaster = new BiconomyPaymaster({
-      paymasterUrl: process.env.PAYMASTER_URL || "",
+      paymasterUrl: "https://paymaster.biconomy.io/api/v1/80001/7K_k68BFN.ed274da8-69a1-496d-a897-508fc2213216",
     })
 
     account = await BiconomySmartAccountV2.create({

--- a/packages/account/tests/SmartAccountV2-Abstract-Paymaster.local.spec.ts
+++ b/packages/account/tests/SmartAccountV2-Abstract-Paymaster.local.spec.ts
@@ -1,4 +1,4 @@
-import { EntryPoint, EntryPoint__factory, UserOperationStruct, SimpleAccountFactory__factory } from "@account-abstraction/contracts";
+import { EntryPoint, EntryPoint__factory } from "@account-abstraction/contracts";
 import { Wallet, ethers } from "ethers";
 import { SampleRecipient, SampleRecipient__factory } from "@account-abstraction/utils/dist/src/types";
 
@@ -15,9 +15,7 @@ import { ChainId } from "@biconomy/core-types";
 import { ECDSAOwnershipValidationModule } from "@biconomy/modules";
 import { BaseValidationModule } from "@biconomy/modules";
 import { ECDSAOwnershipRegistryModule_v100 } from "@biconomy/common";
-import { IHybridPaymaster, PaymasterMode, SponsorUserOperationDto } from "@biconomy/paymaster";
-import { DEFAULT_ENTRYPOINT_ADDRESS } from "../src/utils/Constants";
-import { Bundler, IBundler } from "@biconomy/bundler";
+import { IBundler } from "@biconomy/bundler";
 
 require('dotenv').config();
 
@@ -83,56 +81,5 @@ describe("BiconomySmartAccountV2 Paymaster Abstraction", () => {
 
     expect(address).toBe(account.accountAddress);
   }, 10000);
-
-  // it("Create a smart account with paymaster through api key and send gasless tx", async () => {
-
-  //   account = await BiconomySmartAccountV2.create({
-  //     chainId: ChainId.GANACHE,
-  //     entryPointAddress: entryPoint.address,
-  //     apiKey: process.env.API_KEY,
-  //     factoryAddress: accountFactory.address,
-  //     defaultFallbackHandler: await accountFactory.minimalHandler(),
-  //     defaultValidationModule: module1,
-  //     activeValidationModule: module1,
-  //   });
-
-  //   const address = await account.getAccountAddress();
-  //   console.log("account address ", address);
-
-  //   const paymaster = account.paymaster;
-
-  //   expect(paymaster).not.toBeNull()
-  //   expect(paymaster).not.toBeUndefined()
-
-  //   expect(address).toBe(account.accountAddress);
-
-  //   const randomWallet = ethers.Wallet.createRandom();
-
-  //   const emptyTx = {
-  //     to: randomWallet.address,
-  //     data: "0x",
-  //   };
-
-  //   let userOp = await account.buildUserOp([emptyTx]);
-
-  //   const biconomyPaymaster = account.paymaster as IHybridPaymaster<SponsorUserOperationDto>;
-
-  //   let paymasterServiceData: SponsorUserOperationDto = {
-  //     mode: PaymasterMode.SPONSORED,
-  //     smartAccountInfo: {
-  //       name: 'BICONOMY',
-  //       version: '2.0.0'
-  //     },
-  //   };
-
-  //   const paymasterAndDataResponse = await biconomyPaymaster.getPaymasterAndData(userOp, paymasterServiceData);
-  //   userOp.paymasterAndData = paymasterAndDataResponse.paymasterAndData;
-
-  //   const userOpResponse = await account.sendUserOp(userOp);
-
-  //   console.log(userOpResponse.userOpHash, 'USER OP HASH');
-  //   expect(userOpResponse.userOpHash).not.toBeUndefined();
-
-  // }, 10000);
 
 });

--- a/packages/account/tests/SmartAccountV3.local.spec.ts
+++ b/packages/account/tests/SmartAccountV3.local.spec.ts
@@ -1,0 +1,138 @@
+import { EntryPoint, EntryPoint__factory, UserOperationStruct, SimpleAccountFactory__factory } from "@account-abstraction/contracts";
+import { Wallet, ethers } from "ethers";
+import { SampleRecipient, SampleRecipient__factory } from "@account-abstraction/utils/dist/src/types";
+
+import {
+  SmartAccount_v200,
+  SmartAccountFactory_v200,
+  SmartAccount_v200__factory,
+  SmartAccountFactory_v200__factory,
+  ECDSAOwnershipRegistryModule_v100__factory,
+} from "@biconomy/common";
+
+import { BiconomySmartAccountV2 } from "../src/BiconomySmartAccountV2";
+import { ChainId } from "@biconomy/core-types";
+import { ECDSAOwnershipValidationModule } from "@biconomy/modules";
+import { BaseValidationModule } from "@biconomy/modules";
+import { ECDSAOwnershipRegistryModule_v100 } from "@biconomy/common";
+import { IHybridPaymaster, PaymasterMode, SponsorUserOperationDto } from "@biconomy/paymaster";
+import { DEFAULT_ENTRYPOINT_ADDRESS } from "../src/utils/Constants";
+import { Bundler, IBundler } from "@biconomy/bundler";
+
+require('dotenv').config();
+
+const provider = new ethers.providers.JsonRpcProvider("http://127.0.0.1:8545");
+const signer = provider.getSigner();
+
+describe("BiconomySmartAccountV2 Paymaster Abstraction", () => {
+  let owner: Wallet;
+  let factoryOwner: Wallet;
+  let account: BiconomySmartAccountV2;
+  let entryPoint: EntryPoint;
+  let bundler: IBundler;
+  let beneficiary: string;
+  let recipient: SampleRecipient;
+  let accountFactory: SmartAccountFactory_v200;
+  let ecdsaModule: ECDSAOwnershipRegistryModule_v100;
+
+  let module1: BaseValidationModule;
+
+  beforeAll(async () => {
+    owner = Wallet.createRandom();
+    entryPoint = await new EntryPoint__factory(signer).deploy();
+    console.log("ep address ", entryPoint.address);
+    beneficiary = await signer.getAddress();
+    factoryOwner = Wallet.createRandom();
+
+    const accountImpl: SmartAccount_v200 = await new SmartAccount_v200__factory(signer).deploy(entryPoint.address);
+
+    accountFactory = await new SmartAccountFactory_v200__factory(signer).deploy(accountImpl.address, await factoryOwner.getAddress());
+
+    ecdsaModule = await new ECDSAOwnershipRegistryModule_v100__factory(signer).deploy();
+
+    module1 = await ECDSAOwnershipValidationModule.create({
+      signer: owner,
+      moduleAddress: ecdsaModule.address,
+    });
+
+    console.log("provider url ", provider.connection.url);
+
+    recipient = await new SampleRecipient__factory(signer).deploy();
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+  }, 30000);
+
+  it("Create a smart account with paymaster through api key", async () => {
+
+    account = await BiconomySmartAccountV2.create({
+      chainId: ChainId.GANACHE,
+      entryPointAddress: entryPoint.address,
+      apiKey: process.env.API_KEY,
+      factoryAddress: accountFactory.address,
+      defaultFallbackHandler: await accountFactory.minimalHandler(),
+      defaultValidationModule: module1,
+      activeValidationModule: module1,
+    });
+
+    const address = await account.getAccountAddress();
+    console.log("account address ", address);
+
+    const paymaster = account.paymaster;
+
+    expect(paymaster).not.toBeNull()
+    expect(paymaster).not.toBeUndefined()
+
+    expect(address).toBe(account.accountAddress);
+  }, 10000);
+
+  // it("Create a smart account with paymaster through api key and send gasless tx", async () => {
+
+  //   account = await BiconomySmartAccountV2.create({
+  //     chainId: ChainId.GANACHE,
+  //     entryPointAddress: entryPoint.address,
+  //     apiKey: process.env.API_KEY,
+  //     factoryAddress: accountFactory.address,
+  //     defaultFallbackHandler: await accountFactory.minimalHandler(),
+  //     defaultValidationModule: module1,
+  //     activeValidationModule: module1,
+  //   });
+
+  //   const address = await account.getAccountAddress();
+  //   console.log("account address ", address);
+
+  //   const paymaster = account.paymaster;
+
+  //   expect(paymaster).not.toBeNull()
+  //   expect(paymaster).not.toBeUndefined()
+
+  //   expect(address).toBe(account.accountAddress);
+
+  //   const randomWallet = ethers.Wallet.createRandom();
+
+  //   const emptyTx = {
+  //     to: randomWallet.address,
+  //     data: "0x",
+  //   };
+
+  //   let userOp = await account.buildUserOp([emptyTx]);
+
+  //   const biconomyPaymaster = account.paymaster as IHybridPaymaster<SponsorUserOperationDto>;
+
+  //   let paymasterServiceData: SponsorUserOperationDto = {
+  //     mode: PaymasterMode.SPONSORED,
+  //     smartAccountInfo: {
+  //       name: 'BICONOMY',
+  //       version: '2.0.0'
+  //     },
+  //   };
+
+  //   const paymasterAndDataResponse = await biconomyPaymaster.getPaymasterAndData(userOp, paymasterServiceData);
+  //   userOp.paymasterAndData = paymasterAndDataResponse.paymasterAndData;
+
+  //   const userOpResponse = await account.sendUserOp(userOp);
+
+  //   console.log(userOpResponse.userOpHash, 'USER OP HASH');
+  //   expect(userOpResponse.userOpHash).not.toBeUndefined();
+
+  // }, 10000);
+
+});


### PR DESCRIPTION
# Summary

Related Issue: # (DEVX-336)

## Change Type

- [ ] Bug Fix
- [x] Refactor
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

# Additional Information

The context of this PR is to optimize developer experience of the SDK.
This PR will remove the need for the user/developer to create the Paymaster instance and then provide it to the "create()" method config. Paymaster can be easily setup by only providing an "apiKey" in the config.

Old method of creating instance and providing it to the config by the user/developer is still available for compatibility reasons.
