### PR TITLE
Made entryPointAddress optional

### DIFF
--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -40,7 +40,7 @@ export interface BaseSmartAccountConfig {
   // owner?: Signer // can be in child classes
   index?: number;
   provider?: Provider;
-  entryPointAddress: string;
+  entryPointAddress?: string;
   accountAddress?: string;
   overheads?: Partial<GasOverheads>;
   paymaster?: IPaymaster; // PaymasterAPI


### PR DESCRIPTION
# Summary

Made "entryPointAddress" optional as it is handled in the SDK if not provided by user.

Related Issue: # DEVX-350

## Change Type

- [ ] Bug Fix
- [x] Refactor
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
