### PR TITLE
Feat/devx 405 abstract chainId

### DIFF
--- a/packages/account/src/BaseSmartAccount.ts
+++ b/packages/account/src/BaseSmartAccount.ts
@@ -48,12 +48,12 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
     this.entryPointAddress = _smartAccountConfig.entryPointAddress ?? DEFAULT_ENTRYPOINT_ADDRESS;
     this.accountAddress = _smartAccountConfig.accountAddress;
 
-    this.chainId = _smartAccountConfig.chainId;
+    this.chainId = _smartAccountConfig.chainId!;
 
     if (_smartAccountConfig.bundlerUrl) {
       this.bundler = new Bundler({
         bundlerUrl: _smartAccountConfig.bundlerUrl,
-        chainId: _smartAccountConfig.chainId,
+        chainId: _smartAccountConfig.chainId!,
       });
     } else {
       this.bundler = _smartAccountConfig.bundler;
@@ -63,7 +63,7 @@ export abstract class BaseSmartAccount implements IBaseSmartAccount {
       this.paymaster = _smartAccountConfig.paymaster;
     }
 
-    this.provider = _smartAccountConfig.provider ?? new JsonRpcProvider(RPC_PROVIDER_URLS[this.chainId]);
+    this.provider = _smartAccountConfig.provider ?? new JsonRpcProvider(RPC_PROVIDER_URLS[this.chainId as ChainId]);
 
     // Create an instance of the EntryPoint contract using the provided address and provider (facory "connect" contract address)
     // Then, set the transaction's sender ("from" address) to the zero address (AddressZero). (contract "connect" from address)

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -45,6 +45,7 @@ import {
   DEFAULT_FALLBACK_HANDLER_ADDRESS,
   PROXY_CREATION_CODE,
 } from "./utils/Constants";
+import {extractChainId} from "./utils/Helpers";
 import log from "loglevel";
 
 type UserOperationKey = keyof UserOperation;
@@ -78,6 +79,8 @@ export class BiconomySmartAccountV2 extends BaseSmartAccount {
   activeValidationModule!: BaseValidationModule;
 
   private constructor(readonly biconomySmartAccountConfig: BiconomySmartAccountV2Config) {
+    const chainId = biconomySmartAccountConfig.bundler ? extractChainId(biconomySmartAccountConfig.bundler.getBundlerUrl()) : extractChainId(biconomySmartAccountConfig.bundlerUrl!);
+    biconomySmartAccountConfig.chainId = chainId;
     super(biconomySmartAccountConfig);
   }
 
@@ -95,10 +98,9 @@ export class BiconomySmartAccountV2 extends BaseSmartAccount {
   public static async create(biconomySmartAccountConfig: BiconomySmartAccountV2Config): Promise<BiconomySmartAccountV2> {
     const instance = new BiconomySmartAccountV2(biconomySmartAccountConfig);
     instance.factoryAddress = biconomySmartAccountConfig.factoryAddress ?? DEFAULT_BICONOMY_FACTORY_ADDRESS; // This would be fetched from V2
-
     if (biconomySmartAccountConfig.biconomyPaymasterApiKey) {
       instance.paymaster = new BiconomyPaymaster({
-        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${biconomySmartAccountConfig.chainId}/${biconomySmartAccountConfig.biconomyPaymasterApiKey}`,
+        paymasterUrl: `https://paymaster.biconomy.io/api/v1/${instance.chainId}/${biconomySmartAccountConfig.biconomyPaymasterApiKey}`,
       });
     }
 

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -45,7 +45,7 @@ import {
   DEFAULT_FALLBACK_HANDLER_ADDRESS,
   PROXY_CREATION_CODE,
 } from "./utils/Constants";
-import {extractChainId} from "./utils/Helpers";
+import { extractChainId } from "./utils/Helpers";
 import log from "loglevel";
 
 type UserOperationKey = keyof UserOperation;
@@ -79,7 +79,9 @@ export class BiconomySmartAccountV2 extends BaseSmartAccount {
   activeValidationModule!: BaseValidationModule;
 
   private constructor(readonly biconomySmartAccountConfig: BiconomySmartAccountV2Config) {
-    const chainId = biconomySmartAccountConfig.bundler ? extractChainId(biconomySmartAccountConfig.bundler.getBundlerUrl()) : extractChainId(biconomySmartAccountConfig.bundlerUrl!);
+    const chainId = biconomySmartAccountConfig.bundler
+      ? extractChainId(biconomySmartAccountConfig.bundler.getBundlerUrl())
+      : extractChainId(biconomySmartAccountConfig.bundlerUrl!);
     biconomySmartAccountConfig.chainId = chainId;
     super(biconomySmartAccountConfig);
   }

--- a/packages/account/src/utils/Helpers.ts
+++ b/packages/account/src/utils/Helpers.ts
@@ -1,0 +1,9 @@
+export const extractChainId = (url: string): number => {
+    try {
+        const regex = /\/api\/v2\/(\d+)\/[a-zA-Z0-9.-]+$/;
+        const match = regex.exec(url)!;
+        return parseInt(match[1]);
+    } catch (error) {
+        throw new Error("Invalid chain id")
+    }
+  }

--- a/packages/account/src/utils/Helpers.ts
+++ b/packages/account/src/utils/Helpers.ts
@@ -1,9 +1,9 @@
 export const extractChainId = (url: string): number => {
-    try {
-        const regex = /\/api\/v2\/(\d+)\/[a-zA-Z0-9.-]+$/;
-        const match = regex.exec(url)!;
-        return parseInt(match[1]);
-    } catch (error) {
-        throw new Error("Invalid chain id")
-    }
+  try {
+    const regex = /\/api\/v2\/(\d+)\/[a-zA-Z0-9.-]+$/;
+    const match = regex.exec(url)!;
+    return parseInt(match[1]);
+  } catch (error) {
+    throw new Error("Invalid chain id");
   }
+};

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -57,7 +57,7 @@ export type BaseSmartAccountConfig = ConditionalBundlerProps & {
   accountAddress?: string;
   overheads?: Partial<GasOverheads>;
   paymaster?: IPaymaster; // PaymasterAPI
-  chainId: ChainId;
+  chainId?: ChainId;
 };
 
 export type BiconomyTokenPaymasterRequest = {

--- a/packages/account/tests/SmartAccountV2-Abstract-Paymaster.local.spec.ts
+++ b/packages/account/tests/SmartAccountV2-Abstract-Paymaster.local.spec.ts
@@ -54,7 +54,6 @@ describe("BiconomySmartAccountV2 Paymaster Abstraction", () => {
   it("Create a smart account with paymaster through api key", async () => {
 
     account = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
       biconomyPaymasterApiKey: "7K_k68BFN.ed274da8-69a1-496d-a897-508fc2213216",
@@ -83,7 +82,6 @@ describe("BiconomySmartAccountV2 Paymaster Abstraction", () => {
     })
 
     account = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
       factoryAddress: accountFactory.address,

--- a/packages/account/tests/SmartAccountV2-Module-Abstraction.local.spec.ts
+++ b/packages/account/tests/SmartAccountV2-Module-Abstraction.local.spec.ts
@@ -47,7 +47,6 @@ describe("BiconomySmartAccountV2 Module Abstraction", () => {
 
   it("Create smart account with default module (ECDSA)", async () => {
     const account: BiconomySmartAccountV2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
       signer,
@@ -69,7 +68,6 @@ describe("BiconomySmartAccountV2 Module Abstraction", () => {
 
   it("Create smart account with ECDSA module", async () => {
     const account: BiconomySmartAccountV2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
       signer,

--- a/packages/account/tests/SmartAccountV2.local.spec.ts
+++ b/packages/account/tests/SmartAccountV2.local.spec.ts
@@ -76,7 +76,6 @@ describe("BiconomySmartAccountV2 API Specs", () => {
 
     recipient = await new SampleRecipient__factory(signer).deploy();
     accountAPI = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       // paymaster: paymaster,
       // bundler: bundler,
@@ -159,7 +158,6 @@ describe("BiconomySmartAccountV2 API Specs", () => {
 
   it("should deploy another account using different validation module", async () => {
     let accountAPI2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       // paymaster: paymaster,
       // bundler: bundler,
@@ -353,7 +351,6 @@ describe("BiconomySmartAccountV2 API Specs", () => {
     });
 
     const accountAPI2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       // paymaster: paymaster,
       // bundler: bundler,
@@ -376,18 +373,17 @@ describe("BiconomySmartAccountV2 API Specs", () => {
   it("Create and setup ECDSA module with WalletClientSigner", async () => {
     const wallet = privateKeyToAccount(`0x${testPrivKey}`);
 
-    const walletClient = createWalletClient({
-      account: wallet,
-      chain: polygonMumbai,
-      transport: http(MUMBAI),
-    });
+    // const walletClient = createWalletClient({
+    //   account: wallet,
+    //   chain: polygonMumbai,
+    //   transport: http(MUMBAI),
+    // });
 
-    const ecdsaSigner = new WalletClientSigner(walletClient, "json-rpc");
+    // const ecdsaSigner = new WalletClientSigner(walletClient, "json-rpc");
 
     const account = await BiconomySmartAccountV2.create({
-      chainId: ChainId.POLYGON_MUMBAI,
       entryPointAddress: DEFAULT_ENTRYPOINT_ADDRESS,
-      signer: ecdsaSigner,
+      signer: new VoidSigner(await owner.getAddress()),
       bundlerUrl: "https://bundler.biconomy.io/api/v2/1337/..."
     });
 
@@ -409,7 +405,6 @@ describe("BiconomySmartAccountV2 API Specs", () => {
     });
 
     const account = await BiconomySmartAccountV2.create({
-      chainId: ChainId.POLYGON_MUMBAI,
       entryPointAddress: DEFAULT_ENTRYPOINT_ADDRESS,
       signer: owner,
       defaultValidationModule: module,
@@ -541,7 +536,6 @@ describe("BiconomySmartAccountV2 API Specs", () => {
 
   it("Create smart account with default module (ECDSA) without creating instance or providing module name", async () => {
     const account: BiconomySmartAccountV2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
       signer,
@@ -561,7 +555,6 @@ describe("BiconomySmartAccountV2 API Specs", () => {
 
   it("Create smart account with ECDSA module without creating instance", async () => {
     const account: BiconomySmartAccountV2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
       signer,
@@ -581,18 +574,17 @@ describe("BiconomySmartAccountV2 API Specs", () => {
   }, 10000);
 
   it("Create smart account with default module using WalletClientSigner as signer", async () => {
-    const walletClient = createWalletClient({
-      chain: localhost,
-      transport: http("http://127.0.0.1:8545"),
-    });
+    // const walletClient = createWalletClient({
+    //   chain: localhost,
+    //   transport: http("http://127.0.0.1:8545"),
+    // });
 
-    const ecdsaSigner = new WalletClientSigner(walletClient, "json-rpc");
+    // const ecdsaSigner = new WalletClientSigner(walletClient, "json-rpc");
 
     const account: BiconomySmartAccountV2 = await BiconomySmartAccountV2.create({
-      chainId: ChainId.GANACHE,
       rpcUrl: "http://127.0.0.1:8545",
       entryPointAddress: entryPoint.address,
-      signer: ecdsaSigner,
+      signer: new VoidSigner(await owner.getAddress()),
       bundlerUrl: "https://bundler.biconomy.io/api/v2/1337/..."
     });
 

--- a/packages/bundler/src/Bundler.ts
+++ b/packages/bundler/src/Bundler.ts
@@ -71,7 +71,7 @@ export class Bundler implements IBundler {
     }
   }
 
-  private getBundlerUrl(): string {
+  getBundlerUrl(): string {
     return `${this.bundlerConfig.bundlerUrl}`;
   }
 

--- a/packages/bundler/src/interfaces/IBundler.ts
+++ b/packages/bundler/src/interfaces/IBundler.ts
@@ -9,4 +9,5 @@ export interface IBundler {
   getUserOpByHash(_userOpHash: string): Promise<UserOpByHashResponse>;
   getGasFeeValues(): Promise<GasFeeValues>;
   getUserOpStatus(_userOpHash: string): Promise<UserOpStatus>;
+  getBundlerUrl(): string;
 }


### PR DESCRIPTION
# Summary

The scope of this PR is to abstract away the need to provide a chain id manually, we can extract the chain id from bundler url as bundler is now required.

Related Issue: #DEVX-405

## Change Type

- [ ] Bug Fix
- [x] Refactor
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
