### PR TITLE
AA WalletClientSigner Abstraction

### DIFF
--- a/packages/account/Readme.md
+++ b/packages/account/Readme.md
@@ -38,10 +38,19 @@ The account package achieves this by providing a comprehensive set of methods th
 ```typescript
 // This is how you create a smartWallet in your dapp
 import { Bundler, createSmartWalletClient } from "@biconomy/account";
+import { createWalletClient, http, createPublicClient } from "viem";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import { mainnet as chain } from "viem/chains";
+
+const account = privateKeyToAccount(generatePrivateKey());
+const signer = createWalletClient({
+  account,
+  chain,
+  transport: http(),
+});
 
 const smartWallet = await createSmartWalletClient({
-  chainId: 1,
-  signer, // viem's WalletClientSigner
+  signer,
   bundlerUrl,
 });
 

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -159,7 +159,8 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
     // Signer needs to be initialised here before defaultValidationModule is set
     if (biconomySmartAccountConfig.signer) {
       const signer = biconomySmartAccountConfig.signer;
-      const isViemWalletClient = !(signer instanceof WalletClientSigner);
+      // AA's WalletClientSigner has a signerType, viems' walletClient does not:
+      const isViemWalletClient = !(signer as WalletClientSigner)?.signerType;
       if (isViemWalletClient) {
         const walletClient = signer as WalletClient;
         if (!walletClient.account) {

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -17,8 +17,16 @@ import {
   Chain,
   getContract,
   decodeFunctionData,
+  WalletClient,
 } from "viem";
-import { BaseSmartContractAccount, getChain, type BigNumberish, type UserOperationStruct, BatchUserOperationCallData } from "@alchemy/aa-core";
+import {
+  BaseSmartContractAccount,
+  getChain,
+  type BigNumberish,
+  type UserOperationStruct,
+  BatchUserOperationCallData,
+  WalletClientSigner,
+} from "@alchemy/aa-core";
 import { isNullOrUndefined, packUserOp } from "./utils/Utils";
 import { BaseValidationModule, ModuleInfo, SendUserOpParams, ECDSAOwnershipValidationModule } from "@biconomy/modules";
 import { IHybridPaymaster, IPaymaster, BiconomyPaymaster, SponsorUserOperationDto } from "@biconomy/paymaster";
@@ -32,6 +40,7 @@ import {
   NonceOptions,
   Transaction,
   QueryParamsForAddressResolver,
+  BiconomySmartAccountV2ConfigConstructorProps,
 } from "./utils/Types";
 import {
   ADDRESS_RESOLVER_ADDRESS,
@@ -77,7 +86,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
   // Deployed Smart Account can have more than one module enabled. When sending a transaction activeValidationModule is used to prepare and validate userOp signature.
   activeValidationModule!: BaseValidationModule;
 
-  private constructor(readonly biconomySmartAccountConfig: BiconomySmartAccountV2Config) {
+  private constructor(readonly biconomySmartAccountConfig: BiconomySmartAccountV2ConfigConstructorProps) {
     super({
       ...biconomySmartAccountConfig,
       chain: getChain(biconomySmartAccountConfig.chainId),
@@ -86,6 +95,10 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
       accountAddress: (biconomySmartAccountConfig.accountAddress as Hex) ?? undefined,
       factoryAddress: biconomySmartAccountConfig.factoryAddress ?? DEFAULT_BICONOMY_FACTORY_ADDRESS,
     });
+
+    this.defaultValidationModule = biconomySmartAccountConfig.defaultValidationModule;
+    this.activeValidationModule = biconomySmartAccountConfig.activeValidationModule;
+
     this.index = biconomySmartAccountConfig.index ?? 0;
     this.chainId = biconomySmartAccountConfig.chainId;
     this.bundler = biconomySmartAccountConfig.bundler;
@@ -136,19 +149,49 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    * @throws An error if something is wrong with the smart account instance creation.
    */
   public static async create(biconomySmartAccountConfig: BiconomySmartAccountV2Config): Promise<BiconomySmartAccountV2> {
-    const instance = new BiconomySmartAccountV2(biconomySmartAccountConfig);
+    let chainId = biconomySmartAccountConfig.chainId;
+
+    // Signer needs to be initialised here before defaultValidationModule is set
+    if (biconomySmartAccountConfig.signer) {
+      const signer = biconomySmartAccountConfig.signer;
+      const isViemWalletClient = !(signer instanceof WalletClientSigner);
+      if (isViemWalletClient) {
+        const walletClient = signer as WalletClient;
+        if (!walletClient.account) {
+          throw new Error("Cannot consume a viem wallet without an account");
+        }
+        if (!walletClient.chain) {
+          throw new Error("Cannot consume a viem wallet without a chainId");
+        }
+        chainId = walletClient.chain.id;
+        biconomySmartAccountConfig.signer = new WalletClientSigner(walletClient, "viem");
+      }
+    }
+
+    if (!chainId) {
+      // Chain ID still not found
+      throw new Error("chainId required");
+    }
+
+    let defaultValidationModule = biconomySmartAccountConfig.defaultValidationModule;
 
     // Note: If no module is provided, we will use ECDSA_OWNERSHIP as default
-    if (biconomySmartAccountConfig.defaultValidationModule) {
-      instance.defaultValidationModule = biconomySmartAccountConfig.defaultValidationModule;
-    } else {
-      instance.defaultValidationModule = await ECDSAOwnershipValidationModule.create({
+    if (!defaultValidationModule) {
+      const newModule = await ECDSAOwnershipValidationModule.create({
+        // @ts-expect-error: Signer always present if no defaultValidationModule
         signer: biconomySmartAccountConfig.signer!,
       });
+      defaultValidationModule = newModule;
     }
-    instance.activeValidationModule = biconomySmartAccountConfig.activeValidationModule ?? instance.defaultValidationModule;
+    const activeValidationModule = biconomySmartAccountConfig?.activeValidationModule ?? defaultValidationModule;
+    const config = {
+      ...biconomySmartAccountConfig,
+      defaultValidationModule,
+      activeValidationModule,
+      chainId,
+    };
 
-    return instance;
+    return new BiconomySmartAccountV2(config);
   }
 
   // Calls the getCounterFactualAddress

--- a/packages/account/src/utils/Types.ts
+++ b/packages/account/src/utils/Types.ts
@@ -55,7 +55,15 @@ export interface GasOverheads {
   // MULTICHAIN = DEFAULT_MULTICHAIN_MODULE,
 }*/
 
-export type BaseSmartAccountConfig = ConditionalBundlerProps & {
+type ConditionalBundlerProps = RequireAtLeastOne<
+  {
+    bundler: IBundler;
+    bundlerUrl: string;
+  },
+  "bundler" | "bundlerUrl"
+>;
+
+export type BaseSmartAccountConfig = {
   // owner?: Signer // can be in child classes
   index?: number;
   provider?: WalletClient;
@@ -63,7 +71,7 @@ export type BaseSmartAccountConfig = ConditionalBundlerProps & {
   accountAddress?: string;
   overheads?: Partial<GasOverheads>;
   paymaster?: IPaymaster; // PaymasterAPI
-  chainId: number;
+  chainId?: number;
 };
 
 export type BiconomyTokenPaymasterRequest = {
@@ -90,32 +98,35 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
 type ConditionalValidationProps = RequireAtLeastOne<
   {
     defaultValidationModule: BaseValidationModule;
-    signer: WalletClientSigner;
+    signer: WalletClientSigner | WalletClient;
   },
   "defaultValidationModule" | "signer"
 >;
 
-type ConditionalBundlerProps = RequireAtLeastOne<
-  {
-    bundler: IBundler;
-    bundlerUrl: string;
-  },
-  "bundler" | "bundlerUrl"
->;
+type BiconomySmartAccountV2ConfigBaseProps = {
+  factoryAddress?: Hex;
+  senderAddress?: Hex;
+  implementationAddress?: Hex;
+  defaultFallbackHandler?: Hex;
+  rpcUrl?: string; // as good as Provider
+  nodeClientUrl?: string; // very specific to Biconomy
+  biconomyPaymasterApiKey?: string;
+  activeValidationModule?: BaseValidationModule;
+  scanForUpgradedAccountsFromV1?: boolean;
+  maxIndexForScan?: number;
+};
+export type BiconomySmartAccountV2Config = BiconomySmartAccountV2ConfigBaseProps &
+  BaseSmartAccountConfig &
+  ConditionalBundlerProps &
+  ConditionalValidationProps;
 
-export type BiconomySmartAccountV2Config = BaseSmartAccountConfig &
-  ConditionalValidationProps & {
-    factoryAddress?: Hex;
-    senderAddress?: Hex;
-    implementationAddress?: Hex;
-    defaultFallbackHandler?: Hex;
-    rpcUrl?: string; // as good as Provider
-    nodeClientUrl?: string; // very specific to Biconomy
-    biconomyPaymasterApiKey?: string;
-    activeValidationModule?: BaseValidationModule;
-    scanForUpgradedAccountsFromV1?: boolean;
-    maxIndexForScan?: number;
-  };
+type BiconomySmartAccountV2ConfigResolvedConstructorProps = {
+  defaultValidationModule: BaseValidationModule;
+  activeValidationModule: BaseValidationModule;
+  chainId: number;
+};
+
+export type BiconomySmartAccountV2ConfigConstructorProps = BiconomySmartAccountV2Config & BiconomySmartAccountV2ConfigResolvedConstructorProps;
 
 export type BuildUserOpOptions = {
   overrides?: Overrides;

--- a/packages/account/tests/account.e2e.spec.ts
+++ b/packages/account/tests/account.e2e.spec.ts
@@ -15,16 +15,13 @@ describe("Account Tests", () => {
 
   it("should send some native token to a recipient", async () => {
     const {
-      chainId,
-      whale: { signer, publicAddress: sender },
+      whale: { viemWallet: signer },
       minnow: { publicAddress: recipient },
       bundlerUrl,
-      entryPointAddress,
       publicClient,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       bundlerUrl,
     });
@@ -45,15 +42,12 @@ describe("Account Tests", () => {
 
   it("Create a smart account with paymaster with an api key", async () => {
     const {
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       bundlerUrl,
-      entryPointAddress,
       biconomyPaymasterApiKey,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       biconomyPaymasterApiKey,
       bundlerUrl,
@@ -67,15 +61,13 @@ describe("Account Tests", () => {
   it("Should gaslessly mint an NFT", async () => {
     const nftAddress: Hex = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e";
     const {
-      chainId,
-      whale: { signer, publicAddress: recipient },
+      whale: { viemWallet: signer, publicAddress: recipient },
       bundlerUrl,
       biconomyPaymasterApiKey,
       publicClient,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       biconomyPaymasterApiKey,
       bundlerUrl,
@@ -108,8 +100,7 @@ describe("Account Tests", () => {
 
   it("#getUserOpHash should match entryPoint.getUserOpHash", async () => {
     const {
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       bundlerUrl,
       entryPointAddress,
       publicClient,
@@ -117,7 +108,6 @@ describe("Account Tests", () => {
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       biconomyPaymasterApiKey,
       bundlerUrl,
@@ -151,15 +141,13 @@ describe("Account Tests", () => {
 
   it("should be deployed to counterfactual address", async () => {
     const {
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       bundlerUrl,
       publicClient,
       biconomyPaymasterApiKey,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       biconomyPaymasterApiKey,
       bundlerUrl,
@@ -175,13 +163,11 @@ describe("Account Tests", () => {
     const ecdsaOwnershipModule = "0x0000001c5b32F37F5beA87BDD5374eB2aC54eA8e";
 
     const {
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       bundlerUrl,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       bundlerUrl,
     });

--- a/packages/account/tests/account.spec.ts
+++ b/packages/account/tests/account.spec.ts
@@ -1,4 +1,4 @@
-import { Paymaster, createSmartWalletClient } from "../";
+import { Paymaster, createSmartWalletClient } from "../src";
 import { TestData } from ".";
 
 describe("Account Tests", () => {
@@ -9,17 +9,43 @@ describe("Account Tests", () => {
     chainData = testDataPerChain[0];
   });
 
-  it("should provide an account address", async () => {
+  it("should create a smartWalletClient from a walletClient", async () => {
     const {
-      entryPointAddress,
+      whale: { viemWallet: signer },
       bundlerUrl,
+    } = chainData;
+
+    const smartWallet = await createSmartWalletClient({
+      signer,
+      bundlerUrl,
+    });
+    const address = await smartWallet.getAccountAddress();
+    expect(address).toBeTruthy();
+  });
+
+  it("should create a smartWalletClient from a signer and chainId", async () => {
+    const {
       chainId,
-      whale: { signer },
+      whale: { alchemyWalletClientSigner: signer },
+      bundlerUrl,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
       chainId,
-      entryPointAddress,
+      signer,
+      bundlerUrl,
+    });
+    const address = await smartWallet.getAccountAddress();
+    expect(address).toBeTruthy();
+  });
+
+  it("should provide an account address", async () => {
+    const {
+      bundlerUrl,
+      whale: { viemWallet: signer },
+    } = chainData;
+
+    const smartWallet = await createSmartWalletClient({
       signer,
       bundlerUrl,
     });
@@ -31,13 +57,11 @@ describe("Account Tests", () => {
     const {
       entryPointAddress,
       bundlerUrl,
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       minnow: { publicAddress: recipient },
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       entryPointAddress,
       signer,
       bundlerUrl,
@@ -52,15 +76,11 @@ describe("Account Tests", () => {
 
   it("should have an active validation module", async () => {
     const {
-      entryPointAddress,
       bundlerUrl,
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
-      entryPointAddress,
       signer,
       bundlerUrl,
     });
@@ -71,15 +91,12 @@ describe("Account Tests", () => {
 
   it("Sender should be non zero", async () => {
     const {
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       minnow: { publicAddress: recipient },
       bundlerUrl,
-      entryPointAddress,
     } = chainData;
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       bundlerUrl,
     });
@@ -90,10 +107,8 @@ describe("Account Tests", () => {
 
   it("Create a smart account with paymaster by creating instance", async () => {
     const {
-      chainId,
-      whale: { signer },
+      whale: { viemWallet: signer },
       bundlerUrl,
-      entryPointAddress,
       biconomyPaymasterApiKey,
     } = chainData;
 
@@ -101,7 +116,6 @@ describe("Account Tests", () => {
     const paymaster = new Paymaster({ paymasterUrl });
 
     const smartWallet = await createSmartWalletClient({
-      chainId,
       signer,
       bundlerUrl,
       paymaster,

--- a/packages/account/tests/account.spec.ts
+++ b/packages/account/tests/account.spec.ts
@@ -1,4 +1,7 @@
 import { Paymaster, createSmartWalletClient } from "../src";
+import { createWalletClient, http } from "viem";
+import { localhost } from "viem/chains";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
 import { TestData } from ".";
 
 describe("Account Tests", () => {
@@ -123,4 +126,38 @@ describe("Account Tests", () => {
     expect(smartWallet.paymaster).not.toBeNull();
     expect(smartWallet.paymaster).not.toBeUndefined();
   }, 10000);
+
+  it("should fail to create a smartWalletClient from a walletClient without a chainId", async () => {
+    const { bundlerUrl } = chainData;
+
+    const account = privateKeyToAccount(generatePrivateKey());
+    const viemWalletClientNoChainId = createWalletClient({
+      account,
+      transport: http(localhost.rpcUrls.public.http[0]),
+    });
+
+    expect(
+      async () =>
+        await createSmartWalletClient({
+          signer: viemWalletClientNoChainId,
+          bundlerUrl,
+        }),
+    ).rejects.toThrow("Cannot consume a viem wallet without a chainId");
+  });
+
+  it("should fail to create a smartWalletClient from a walletClient without an account", async () => {
+    const { bundlerUrl } = chainData;
+
+    const viemWalletNoAccount = createWalletClient({
+      transport: http(localhost.rpcUrls.public.http[0]),
+    });
+
+    expect(
+      async () =>
+        await createSmartWalletClient({
+          signer: viemWalletNoAccount,
+          bundlerUrl,
+        }),
+    ).rejects.toThrow("Cannot consume a viem wallet without an account");
+  });
 });

--- a/packages/account/tests/index.d.ts
+++ b/packages/account/tests/index.d.ts
@@ -2,8 +2,8 @@ import { Chain, Hex, PrivateKeyAccount, PublicClient, WalletClient } from "viem"
 import { WalletClientSigner } from "@alchemy/aa-core";
 
 interface WalletProps {
-  signer: WalletClientSigner;
-  walletClient: WalletClient;
+  alchemyWalletClientSigner: WalletClientSigner;
+  viemWallet: WalletClient;
   balance: BigInt;
   publicAddress: Hex;
   account: PrivateKeyAccount;

--- a/packages/bundler/tests/index.d.ts
+++ b/packages/bundler/tests/index.d.ts
@@ -2,8 +2,8 @@ import { Chain, Hex, PrivateKeyAccount, PublicClient, WalletClient } from "viem"
 import { WalletClientSigner } from "@alchemy/aa-core";
 
 interface WalletProps {
-  signer: WalletClientSigner;
-  walletClient: WalletClient;
+  alchemyWalletClientSigner: WalletClientSigner;
+  viemWallet: WalletClient;
   balance: BigInt;
   publicAddress: Hex;
   account: PrivateKeyAccount;

--- a/packages/paymaster/tests/index.d.ts
+++ b/packages/paymaster/tests/index.d.ts
@@ -2,8 +2,8 @@ import { Chain, Hex, PrivateKeyAccount, PublicClient, WalletClient } from "viem"
 import { WalletClientSigner } from "@alchemy/aa-core";
 
 interface WalletProps {
-  signer: WalletClientSigner;
-  walletClient: WalletClient;
+  alchemyWalletClientSigner: WalletClientSigner;
+  viemWallet: WalletClient;
   balance: BigInt;
   publicAddress: Hex;
   account: PrivateKeyAccount;

--- a/setup-e2e-tests.ts
+++ b/setup-e2e-tests.ts
@@ -28,18 +28,19 @@ beforeAll(async () => {
       chain: chain.viemChain,
       transport: http(),
     });
-    const walletOneClient = createWalletClient({
+
+    const viemWalletClientOne = createWalletClient({
       account: walletOne,
       chain: chain.viemChain,
       transport: http(chain.viemChain.rpcUrls.public.http[0]),
     });
-    const walletTwoClient = createWalletClient({
+    const viemWalletClientTwo = createWalletClient({
       account: walletTwo,
       chain: chain.viemChain,
       transport: http(chain.viemChain.rpcUrls.public.http[0]),
     });
-    const signerOne = new WalletClientSigner(walletOneClient, "json-rpc");
-    const signerTwo = new WalletClientSigner(walletTwoClient, "json-rpc");
+    const walletClientSignerOne = new WalletClientSigner(viemWalletClientOne, "viem");
+    const walletClientSignerTwo = new WalletClientSigner(viemWalletClientTwo, "viem");
 
     return Promise.all([
       Promise.all([
@@ -48,8 +49,8 @@ beforeAll(async () => {
           publicClient,
           account: walletOne,
           publicAddress: walletOne.address,
-          signer: signerOne,
-          walletClient: walletOneClient,
+          viemWallet: viemWalletClientOne,
+          alchemyWalletClientSigner: walletClientSignerOne,
         },
         publicClient.getBalance({
           address: walletOne.address,
@@ -61,8 +62,8 @@ beforeAll(async () => {
           publicClient,
           account: walletTwo,
           publicAddress: walletTwo.address,
-          signer: signerTwo,
-          walletClient: walletTwoClient,
+          viemWallet: viemWalletClientTwo,
+          alchemyWalletClientSigner: walletClientSignerTwo,
         },
         publicClient.getBalance({
           address: walletTwo.address,
@@ -100,15 +101,15 @@ beforeAll(async () => {
       biconomyPaymasterApiKey: whaleBalance.biconomyPaymasterApiKey,
       whale: {
         balance: whaleBalance.balance,
-        signer: whaleBalance.signer,
-        walletClient: whaleBalance.walletClient,
+        viemWallet: whaleBalance.viemWallet,
+        alchemyWalletClientSigner: whaleBalance.alchemyWalletClientSigner,
         publicAddress: whaleBalance.publicAddress,
         account: whaleBalance.account,
       },
       minnow: {
         balance: minnowBalance.balance,
-        signer: minnowBalance.signer,
-        walletClient: minnowBalance.walletClient,
+        viemWallet: minnowBalance.viemWallet,
+        alchemyWalletClientSigner: minnowBalance.alchemyWalletClientSigner,
         publicAddress: minnowBalance.publicAddress,
         account: minnowBalance.account,
       },

--- a/setup-unit-tests.ts
+++ b/setup-unit-tests.ts
@@ -16,12 +16,12 @@ beforeAll(() => {
   const chain = TEST_CHAIN;
   const { chainId, bundlerUrl, viemChain, entryPointAddress } = chain;
   const accountOne = mnemonicToAccount(MNEMONIC);
-  const walletClientOne = createWalletClient({
+  const viemWalletClientOne = createWalletClient({
     account: accountOne,
     chain: viemChain,
     transport: http(viemChain.rpcUrls.public.http[0]),
   });
-  const signerOne = new WalletClientSigner(walletClientOne, "json-rpc");
+  const walletClientSignerOne = new WalletClientSigner(viemWalletClientOne, "viem");
   const publicAddressOne = accountOne.address;
   const publicClient = createPublicClient({
     chain: viemChain,
@@ -29,24 +29,24 @@ beforeAll(() => {
   });
 
   const accountTwo = privateKeyToAccount(generatePrivateKey());
-  const walletClientTwo = createWalletClient({
+  const viemWalletClientTwo = createWalletClient({
     account: accountTwo,
     chain: viemChain,
     transport: http(viemChain.rpcUrls.public.http[0]),
   });
-  const signerTwo = new WalletClientSigner(walletClientTwo, "json-rpc");
+  const walletClientSignerTwo = new WalletClientSigner(viemWalletClientTwo, "viem");
   const publicAddressTwo = accountTwo.address;
 
   const whale = {
-    signer: signerOne,
-    walletClient: walletClientOne,
+    viemWallet: viemWalletClientOne,
+    alchemyWalletClientSigner: walletClientSignerOne,
     balance: 0,
     publicAddress: publicAddressOne,
   };
 
   const minnow = {
-    signer: signerTwo,
-    walletClient: walletClientTwo,
+    viemWallet: viemWalletClientTwo,
+    alchemyWalletClientSigner: walletClientSignerTwo,
     balance: 0,
     publicAddress: publicAddressTwo,
   };


### PR DESCRIPTION
# Summary

This PR facilitates the use of viems' `walletClient` as the signer while instantiating the smartWallet. 

Previously:

```
import {  WalletClientSigner } from "@alchemy/aa-core";
import { createSmartWalletClient } from "@biconomy/account"

const aaWalletClientSigner = new WalletClientSigner(viemWalletClient, "viem");
const smartWallet = await createSmartWalletClient({ chainId, signer:  aaWalletClientSigner})

```

Now:

```
import { createSmartWalletClient } from "@biconomy/account"
const smartWallet = await createSmartWalletClient({ signer:  viemWalletClient})
```

The chainId is now inferred from viem's walletClient

Related Issue: DEVX-405
Resolved: DEVX-422

## Change Type

- [ ] Bug Fix
- [ ] Refactor
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [x] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

# Additional Information

This PR abstracts away AAs WalletClientSigner, so that viems' walletClient can be used as the signer instead.

We're doing work in the BiconomySmartAccountV2 before moving props into the constructor. This PR separates out types of the config passed into the static create call and types sent to the constructor.