### PR TITLE
Resolved SMA-551

### DIFF
--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -50,6 +50,7 @@ import {
   QueryParamsForAddressResolver,
   BiconomySmartAccountV2ConfigConstructorProps,
   PaymasterUserOperationDto,
+  TransactionResponse,
 } from "./utils/Types";
 import {
   ADDRESS_RESOLVER_ADDRESS,
@@ -754,13 +755,14 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    *   data: encodedCall
    * }
    *
-   * const { waitForTxHash } = await smartWallet.sendTransaction(transaction);
+   * const { wait } = await smartWallet.sendTransaction(transaction);
    * const { transactionHash, userOperationReceipt } = await wait();
    *
    */
-  async sendTransaction(manyOrOneTransactions: Transaction | Transaction[], buildUseropDto?: BuildUserOpOptions): Promise<UserOpResponse> {
+  async sendTransaction(manyOrOneTransactions: Transaction | Transaction[], buildUseropDto?: BuildUserOpOptions): Promise<TransactionResponse> {
     const userOp = await this.buildUserOp(Array.isArray(manyOrOneTransactions) ? manyOrOneTransactions : [manyOrOneTransactions], buildUseropDto);
-    return this.sendUserOp(userOp);
+    const { wait: waitForUserOp, waitForTxHash: wait, ...other } = await this.sendUserOp(userOp);
+    return { wait, waitForUserOp, ...other };
   }
 
   /**

--- a/packages/bundler/src/utils/Types.ts
+++ b/packages/bundler/src/utils/Types.ts
@@ -65,7 +65,14 @@ export type UserOpResponse = {
   // Review: waitForTxHash(): vs waitForTxHash?():
   waitForTxHash(): Promise<UserOpStatus>;
 };
-
+export type TransactionResponse = {
+  /** userOpHash of the transaction. */
+  userOpHash: string;
+  /** Wait for the tx to be mined - onchain */
+  wait(): Promise<UserOpStatus>;
+  /** Wait for the userOpHash to be processed by the bundler - offchain */
+  waitForUserOp(_confirmations?: number): Promise<UserOpReceipt>;
+};
 // Converted to JsonRpcResponse with strict type
 export type EstimateUserOpGasResponse = {
   jsonrpc: string;


### PR DESCRIPTION
# Summary

Currently waiting on sendTransaction will wait for the userOp response.

To align with viem (and the sendTransaction terminology) we should wait to resolve only after the tx is mined.
Related Issue: #SMA-551

## Change Type

- [ ] Bug Fix
- [ ] Refactor
- [ ] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [x] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [x] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published