### PR TITLE
For discussion: Do not merge

### DIFF
--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -502,7 +502,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
     userOp: Partial<UserOperationStruct>,
     paymasterServiceData: FeeQuotesOrDataDto,
   ) => {
-    return await (this.paymaster as IHybridPaymaster<PaymasterUserOperationDto>).getPaymasterFeeQuotesOrData(userOp, paymasterServiceData);
+    return (this.paymaster as IHybridPaymaster<PaymasterUserOperationDto>).getPaymasterFeeQuotesOrData(userOp, paymasterServiceData);
   };
 
   /**

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -65,6 +65,7 @@ import { BiconomyAccountAbi } from "./abi/SmartAccount";
 import { AccountResolverAbi } from "./abi/AccountResolver";
 import { Logger } from "@biconomy/common";
 import { convertSigner } from "./";
+import { FeeQuotesOrDataDto } from "@biconomy/paymaster";
 
 type UserOperationKey = keyof UserOperationStruct;
 
@@ -496,6 +497,13 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
     const moduleAddressToUse = moduleAddress ?? (this.activeValidationModule.getAddress() as Hex);
     return encodeAbiParameters(parseAbiParameters("bytes, address"), [moduleSignature, moduleAddressToUse]);
   }
+
+  public getPaymasterFeeQuotesOrData: Paymaster["getPaymasterFeeQuotesOrData"] = async (
+    userOp: Partial<UserOperationStruct>,
+    paymasterServiceData: FeeQuotesOrDataDto,
+  ) => {
+    return await (this.paymaster as IHybridPaymaster<PaymasterUserOperationDto>).getPaymasterFeeQuotesOrData(userOp, paymasterServiceData);
+  };
 
   /**
    *


### PR DESCRIPTION
There's very little tangible difference (~3% ish?) between the times for the optimised flow and the not-optimised flow, but the not-optimised call is much nicer DX. I would prefer to document that latter and not the former, so we don't have to change docs after we eventually bake in the optimisation to buildUserOp. I've added a test here with the nicer dx. We can bake the optimisation into the `sendTransaction` in v4.1 and keep `getPaymasterUserOp` for internal use only for now. We could make it a private method by adding a `#`: `#getPaymasterUserOp`.

<img width="297" alt="image" src="https://github.com/bcnmy/biconomy-client-sdk/assets/4627587/a286c31b-40ac-4728-8e97-1af77386df33">

<img width="254" alt="image" src="https://github.com/bcnmy/biconomy-client-sdk/assets/4627587/c595ccab-c5d7-44a1-a93f-a988d50ee81e">

