### PR TITLE
Add ethersV6 compatibility

### DIFF
--- a/packages/common/src/utils/Types.ts
+++ b/packages/common/src/utils/Types.ts
@@ -3,9 +3,9 @@ import { Signer } from "@ethersproject/abstract-signer";
 import { SmartAccountSigner } from "@alchemy/aa-core";
 
 export type SupportedSignerName = "alchemy" | "ethers" | "viem";
-export type SupportedSigner = SmartAccountSigner | WalletClient | Signer | LightSigner;
+export type SupportedSigner = SmartAccountSigner | WalletClient | Signer | EthersV6Signer;
 
-export interface LightSigner {
+export interface EthersV6Signer {
   getAddress(): Promise<string>;
   signMessage(message: string | Uint8Array): Promise<string>;
 }

--- a/packages/common/src/utils/Types.ts
+++ b/packages/common/src/utils/Types.ts
@@ -1,6 +1,11 @@
-import { SmartAccountSigner } from "@alchemy/aa-core";
 import { WalletClient } from "viem";
 import { Signer } from "@ethersproject/abstract-signer";
+import { SmartAccountSigner } from "@alchemy/aa-core";
 
 export type SupportedSignerName = "alchemy" | "ethers" | "viem";
-export type SupportedSigner = SmartAccountSigner | WalletClient | Signer;
+export type SupportedSigner = SmartAccountSigner | WalletClient | Signer | LightSigner;
+
+export interface LightSigner {
+  getAddress(): Promise<string>;
+  signMessage(message: string | Uint8Array): Promise<string>;
+}


### PR DESCRIPTION
# Summary

Added a helper interface in order to support signer type from ethersV6.

## Change Type

- [ ] Bug Fix
- [x] Refactor
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [ ] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

# Additional Information
