### PR TITLE
Change type: sessionSigner: SupportedSigner

### DIFF
--- a/packages/modules/src/BatchedSessionRouterModule.ts
+++ b/packages/modules/src/BatchedSessionRouterModule.ts
@@ -9,6 +9,7 @@ import { SessionKeyManagerModule } from "./SessionKeyManagerModule.js";
 import { SessionSearchParam, SessionStatus } from "./interfaces/ISessionStorage.js";
 import { Hex, concat, encodeAbiParameters, keccak256, pad, parseAbiParameters, toBytes, toHex } from "viem";
 import { SmartAccountSigner } from "@alchemy/aa-core";
+import { convertSigner } from "@biconomy/common";
 
 export class BatchedSessionRouterModule extends BaseValidationModule {
   version: ModuleVersion = "V1_0_0";
@@ -97,7 +98,7 @@ export class BatchedSessionRouterModule extends BaseValidationModule {
     const sessionDataTupleArray = [];
 
     // signer must be the same for all the sessions
-    const sessionSigner = sessionParams[0].sessionSigner;
+    const { signer: sessionSigner } = await convertSigner(sessionParams[0].sessionSigner);
 
     const signature = await sessionSigner.signMessage(toBytes(userOpHash));
 
@@ -208,7 +209,7 @@ export class BatchedSessionRouterModule extends BaseValidationModule {
     // if needed we could do mock signature over userOpHashAndModuleAddress
 
     // signer must be the same for all the sessions
-    const sessionSigner = sessionParams[0].sessionSigner;
+    const { signer: sessionSigner } = await convertSigner(sessionParams[0].sessionSigner);
 
     for (const sessionParam of sessionParams) {
       if (!sessionParam.sessionSigner) {

--- a/packages/modules/src/SessionKeyManagerModule.ts
+++ b/packages/modules/src/SessionKeyManagerModule.ts
@@ -14,6 +14,7 @@ import { generateRandomHex } from "./utils/Uid.js";
 import { BaseValidationModule } from "./BaseValidationModule.js";
 import { SessionLocalStorage } from "./session-storage/SessionLocalStorage.js";
 import { ISessionStorage, SessionLeafNode, SessionSearchParam, SessionStatus } from "./interfaces/ISessionStorage.js";
+import { convertSigner } from "@biconomy/common";
 
 export class SessionKeyManagerModule extends BaseValidationModule {
   version: ModuleVersion = "V1_0_0";
@@ -158,7 +159,8 @@ export class SessionKeyManagerModule extends BaseValidationModule {
     if (!(params && params.sessionSigner)) {
       throw new Error("Session signer is not provided.");
     }
-    const sessionSigner = params.sessionSigner;
+    const { signer: sessionSigner } = await convertSigner(params.sessionSigner);
+
     // Use the sessionSigner to sign the user operation
     const signature = await sessionSigner.signMessage(toBytes(userOpHash));
 
@@ -192,7 +194,7 @@ export class SessionKeyManagerModule extends BaseValidationModule {
     if (!(params && params.sessionSigner)) {
       throw new Error("Session signer is not provided.");
     }
-    const sessionSigner = params.sessionSigner;
+    const { signer: sessionSigner } = await convertSigner(params.sessionSigner);
     let sessionSignerData;
     if (params?.sessionID) {
       sessionSignerData = await this.sessionStorageClient.getSessionData({

--- a/packages/modules/src/utils/Types.ts
+++ b/packages/modules/src/utils/Types.ts
@@ -52,7 +52,7 @@ export enum StorageType {
 
 export type SessionParams = {
   sessionID?: string;
-  sessionSigner: SmartAccountSigner;
+  sessionSigner: SupportedSigner;
   sessionValidationModule?: Hex;
   additionalSessionData?: string;
 };
@@ -61,7 +61,7 @@ export type ModuleInfo = {
   // Could be a full object of below params and that way it can be an array too!
   // sessionParams?: SessionParams[] // where SessionParams is below four
   sessionID?: string;
-  sessionSigner?: SmartAccountSigner;
+  sessionSigner?: SupportedSigner;
   sessionValidationModule?: Hex;
   additionalSessionData?: string;
   batchSessionParams?: SessionParams[];

--- a/packages/modules/tests/sessionValidationModule.e2e.spec.ts
+++ b/packages/modules/tests/sessionValidationModule.e2e.spec.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SESSION_KEY_MANAGER_MODULE, SessionKeyManagerModule } from "@biconomy/modules";
+import { DEFAULT_SESSION_KEY_MANAGER_MODULE, createSessionKeyManagerModule } from "@biconomy/modules";
 import { SessionFileStorage } from "./utils/customSession";
 import { WalletClientSigner, createSmartAccountClient } from "../../account/src/index";
 import { Hex, encodeAbiParameters, encodeFunctionData, parseAbi, parseUnits } from "viem";
@@ -49,7 +49,7 @@ describe("Account Tests", () => {
     });
 
     // Create session module
-    const sessionModule = await SessionKeyManagerModule.create({
+    const sessionModule = await createSessionKeyManagerModule({
       moduleAddress: DEFAULT_SESSION_KEY_MANAGER_MODULE,
       smartAccountAddress: await smartWallet.getAddress(),
       sessionStorageClient: sessionFileStorage,


### PR DESCRIPTION
# Summary

Currently the sessionSigner is expected to be of type SmartAccountSigner, which is unpleasant DX. This changes the type to: SupportedSigner and handles the appropriate cases where alternative signers are provided

Related Issue: # (issue number)

## Change Type

- [x] Bug Fix
- [ ] Refactor
- [x] New Feature
- [] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [ ] My code follows this project's style guidelines
- [ ] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [ ] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published