### PR TITLE
Feat(SMA-579): Allow empty tokenInfo fields during getTokenFees

### DIFF
--- a/linkAll.sh
+++ b/linkAll.sh
@@ -1,3 +1,3 @@
 !/bin/sh
 for dir in ./packages/*; do (cd "$dir" && yarn link); done
-cd ./packages/account && yarn link '@biconomy/bundler' '@biconomy/modules' '@biconomy/paymaster' '@biconomy/common'
+cd ./packages/account && yarn link '@biconomy/bundler' '@biconomy/modules' '@biconomy/paymaster' '@biconomy/common' 

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "docs": "typedoc",
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -535,8 +535,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
           throw new Error("Error while getting feeQuote");
         }
         return this.getPaymasterAndData(userOp, { ...paymasterServiceData, feeQuote, spender, feeTokenAddress: preferredToken });
-       } 
-       else {
+      } else {
         return userOp;
       }
     }
@@ -557,8 +556,12 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
     feeQuotesOrData: FeeQuotesOrDataDto,
   ): Promise<FeeQuotesOrDataResponse> {
     const paymaster = this.paymaster as IHybridPaymaster<PaymasterUserOperationDto>;
-    const tokenList = feeQuotesOrData?.preferredToken ? [feeQuotesOrData?.preferredToken] : feeQuotesOrData?.tokenList?.length ? feeQuotesOrData?.tokenList : [];
-    return paymaster.getPaymasterFeeQuotesOrData(userOp, { ...feeQuotesOrData, tokenList});
+    const tokenList = feeQuotesOrData?.preferredToken
+      ? [feeQuotesOrData?.preferredToken]
+      : feeQuotesOrData?.tokenList?.length
+        ? feeQuotesOrData?.tokenList
+        : [];
+    return paymaster.getPaymasterFeeQuotesOrData(userOp, { ...feeQuotesOrData, tokenList });
   }
 
   /**
@@ -566,7 +569,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    * @description This function will retrieve fees from the paymaster in erc20 mode
    *
    * @param manyOrOneTransactions Array of {@link Transaction} to be batched and sent. Can also be a single {@link Transaction}.
-   * @param buildUseropDto {@link BuildUserOpOptions}.
+   * @param buildUseropDto {@link BuildUserOpOptions}. Also relevant is the {@link FeeQuoteParams} param.
    * @returns Promise<FeeQuotesOrDataResponse>
    *
    * @example
@@ -594,11 +597,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    * }
    *
    * const feeQuotesResponse: FeeQuotesOrDataResponse = await smartWallet.getTokenFees(transaction, {
-   *    paymasterServiceData: {
-   *      mode: PaymasterMode.ERC20,
-   *      tokenList: ["0xda5289fcaaf71d52a80a254da614a192b693e977"],
-   *      preferredToken: "0xda5289fcaaf71d52a80a254da614a192b693e977"
-   *    }
+   *    paymasterServiceData: { mode: PaymasterMode.ERC20 }
    * });
    *
    * const userSeletedFeeQuote = feeQuotesResponse.feeQuotes?.[0];

--- a/packages/account/src/BiconomySmartAccountV2.ts
+++ b/packages/account/src/BiconomySmartAccountV2.ts
@@ -535,8 +535,9 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
           throw new Error("Error while getting feeQuote");
         }
         return this.getPaymasterAndData(userOp, { ...paymasterServiceData, feeQuote, spender, feeTokenAddress: preferredToken });
-      } else {
-        throw new Error("FeeQuote was not provided, please call smartAccount.getTokenFees() to get feeQuote");
+       } 
+       else {
+        return userOp;
       }
     }
     throw new Error("Invalid paymaster mode");
@@ -556,7 +557,8 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
     feeQuotesOrData: FeeQuotesOrDataDto,
   ): Promise<FeeQuotesOrDataResponse> {
     const paymaster = this.paymaster as IHybridPaymaster<PaymasterUserOperationDto>;
-    return paymaster.getPaymasterFeeQuotesOrData(userOp, feeQuotesOrData);
+    const tokenList = feeQuotesOrData?.preferredToken ? [feeQuotesOrData?.preferredToken] : feeQuotesOrData?.tokenList?.length ? feeQuotesOrData?.tokenList : [];
+    return paymaster.getPaymasterFeeQuotesOrData(userOp, { ...feeQuotesOrData, tokenList});
   }
 
   /**

--- a/packages/account/src/utils/Constants.ts
+++ b/packages/account/src/utils/Constants.ts
@@ -56,3 +56,9 @@ export const DefaultGasLimit = {
   verificationGasLimit: 1000000,
   preVerificationGas: 100000,
 };
+
+export const ERROR_MESSAGES = {
+  SPENDER_REQUIRED: "spender is required for ERC20 mode",
+  NO_FEE_QUOTE: "FeeQuote was not provided, please call smartAccount.getTokenFees() to get feeQuote",
+  FAILED_FEE_QUOTE_FETCH: "Failed to fetch fee quote",
+};

--- a/packages/account/tests/account.e2e.spec.ts
+++ b/packages/account/tests/account.e2e.spec.ts
@@ -167,6 +167,37 @@ describe("Account Tests", () => {
     expect(newBalance - balance).toBe(1n);
   }, 60000);
 
+  it("Should expect several feeQuotes in resonse to empty tokenInfo fields", async () => {
+    const nftAddress: Hex = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e";
+    const {
+      whale: { viemWallet: signer, publicAddress: recipient },
+      bundlerUrl,
+      biconomyPaymasterApiKey,
+      publicClient,
+    } = mumbai;
+
+    const smartWallet = await createSmartAccountClient({
+      signer,
+      bundlerUrl,
+      biconomyPaymasterApiKey,
+    });
+
+    const encodedCall = encodeFunctionData({
+      abi: parseAbi(["function safeMint(address _to)"]),
+      functionName: "safeMint",
+      args: [recipient],
+    });
+
+    const transaction = {
+      to: nftAddress, // NFT address
+      data: encodedCall,
+    };
+
+    const feeQuotesResponse = await smartWallet.getTokenFees(transaction, { paymasterServiceData: { mode: PaymasterMode.ERC20 } } );
+    expect(feeQuotesResponse.feeQuotes?.length).toBeGreaterThan(1);
+
+  })
+
   it("Should mint an NFT on Mumbai and pay with ERC20 - with token selection", async () => {
     const nftAddress: Hex = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e";
     const {

--- a/packages/account/tests/account.e2e.spec.ts
+++ b/packages/account/tests/account.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { TestData } from "../../../tests";
-import { createSmartAccountClient, FeeQuotesOrDataResponse, PaymasterMode } from "../src/index";
+import { createSmartAccountClient, ERROR_MESSAGES, FeeQuotesOrDataResponse, PaymasterMode } from "../src/index";
 import { Hex, encodeFunctionData, parseAbi } from "viem";
 import { UserOperationStruct } from "@alchemy/aa-core";
 import { checkBalance, entryPointABI } from "../../../tests/utils";
@@ -192,10 +192,9 @@ describe("Account Tests", () => {
       data: encodedCall,
     };
 
-    const feeQuotesResponse = await smartWallet.getTokenFees(transaction, { paymasterServiceData: { mode: PaymasterMode.ERC20 } } );
+    const feeQuotesResponse = await smartWallet.getTokenFees(transaction, { paymasterServiceData: { mode: PaymasterMode.ERC20 } });
     expect(feeQuotesResponse.feeQuotes?.length).toBeGreaterThan(1);
-
-  })
+  });
 
   it("Should mint an NFT on Mumbai and pay with ERC20 - with token selection", async () => {
     const nftAddress: Hex = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e";
@@ -303,7 +302,7 @@ describe("Account Tests", () => {
         },
         simulationType: "validation",
       }),
-    ).rejects.toThrow("spender and maxApproval are required for ERC20 mode");
+    ).rejects.toThrow(ERROR_MESSAGES.SPENDER_REQUIRED);
   }, 60000);
 
   it("#getUserOpHash should match entryPoint.getUserOpHash", async () => {

--- a/packages/account/tests/account.e2e.spec.ts
+++ b/packages/account/tests/account.e2e.spec.ts
@@ -173,7 +173,6 @@ describe("Account Tests", () => {
       whale: { viemWallet: signer, publicAddress: recipient },
       bundlerUrl,
       biconomyPaymasterApiKey,
-      publicClient,
     } = mumbai;
 
     const smartWallet = await createSmartAccountClient({

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",

--- a/packages/particle-auth/package.json
+++ b/packages/particle-auth/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",

--- a/packages/paymaster/package.json
+++ b/packages/paymaster/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",

--- a/packages/transak/package.json
+++ b/packages/transak/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "unbuild": "rimraf dist *.tsbuildinfo",
-    "build:watch": "node .esbuild.js CJS --watch",
+    "build:watch": "yarn build:tsc --watch",
     "dist:minify": "esbuild ./dist/esm/**/*.js ./dist/esm/*.js --minify --outdir=./dist/esm --bundle=false --allow-overwrite",
     "build": "yarn unbuild && yarn build:tsc",
     "build:esbuild": "yarn build:esbuild:cjs && yarn build:esbuild:esm && yarn build:typ",


### PR DESCRIPTION
# Summary

This PR allows for the following bare-bones params to be accepted, returning a list of quotes for supported tokens on the chain / paymaster

```
 { paymasterServiceData: { mode: PaymasterMode.ERC20 } }
```
Related Issue: # (issue number)

## Change Type

- [x] Bug Fix
- [ ] Refactor
- [ ] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [x] My code follows this project's style guidelines
- [X] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [x] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published