### PR TITLE
added fetch for token balance in getSupportedTokens

### DIFF
--- a/src/account/BiconomySmartAccountV2.ts
+++ b/src/account/BiconomySmartAccountV2.ts
@@ -345,9 +345,9 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
   }
 
   /**
-   * Returns token balances (and native token balance) of the smartAccount instance.
+   * Returns tokens balance and information of the tokens (for native and erc20 tokens) for the smartAccount instance.
    *
-   * This method will fetch the token balances of the smartAccount instance.
+   * This method will fetch tokens info given an array of token addresses for the smartAccount instance.
    * The balance of the native token will always be returned as the last element in the reponse array, with the address set to 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE.
    *
    * @param addresses - Optional. Array of asset addresses to fetch the balances of. If not provided, the method will return only the balance of the native token.
@@ -367,7 +367,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    *
    * const token = "0x747A4168DB14F57871fa8cda8B5455D8C2a8e90a";
    * const smartAccount = await createSmartAccountClient({ signer, bundlerUrl });
-   * const [tokenBalanceFromSmartAccount, nativeTokenBalanceFromSmartAccount] = await smartAccount.getBalances([token]);
+   * const [tokenBalanceFromSmartAccount, nativeTokenBalanceFromSmartAccount] = await smartAccount.getTokenBalancesInfo([token]);
    *
    * console.log(tokenBalanceFromSmartAccount);
    * // {
@@ -380,7 +380,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    *
    * // or to get the nativeToken balance
    *
-   * const [nativeTokenBalanceFromSmartAccount] = await smartAccount.getBalances();
+   * const [nativeTokenBalanceFromSmartAccount] = await smartAccount.getTokenBalancesInfo();
    *
    * console.log(nativeTokenBalanceFromSmartAccount);
    * // {
@@ -392,7 +392,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    * // }
    *
    */
-  public async getBalances(
+  public async getTokenBalancesInfo(
     addresses?: Array<Hex>
   ): Promise<Array<BalancePayload>> {
     const accountAddress = await this.getAccountAddress()
@@ -440,6 +440,49 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
     })
 
     return result
+  }
+
+  /**
+   * Returns a single token balance for the smartAccount instance.
+   *
+   * This method will fetch only the token balance of a given token address for the smart account
+   *
+   * @param address - Required. Address of the asset to fetch the balance of. If not passed, the native balance of the smart account will be fetched.
+   * @returns Promise<bigint> - The token balance of the smart account
+   *
+   * @example
+   * import { createClient } from "viem"
+   * import { createSmartAccountClient } from "@biconomy/account"
+   * import { createWalletClient, http } from "viem";
+   * import { polygonAmoy } from "viem/chains";
+   *
+   * const signer = createWalletClient({
+   *   account,
+   *   chain: polygonAmoy,
+   *   transport: http(),
+   * });
+   *
+   * const token = "0x747A4168DB14F57871fa8cda8B5455D8C2a8e90a";
+   * const smartAccount = await createSmartAccountClient({ signer, bundlerUrl });
+   * const tokenBalance = await smartAccount.getTokenBalance(token);
+   *
+   * console.log(tokenBalance);
+   * // 83546776652078153068n
+   *
+   */
+  public async getTokenBalance(address?: Hex): Promise<bigint> {
+    const accountAddress = await this.getAccountAddress()
+
+    if (isNullOrUndefined(address))
+      return await this.provider.getBalance({ address: accountAddress })
+
+    const tokenContract = getContract({
+      address,
+      abi: parseAbi(ERC20_ABI),
+      client: this.provider
+    })
+
+    return tokenContract.read.balanceOf([accountAddress]) as Promise<bigint>
   }
 
   /**
@@ -510,7 +553,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
 
     // Get the balances of the tokens if the amount is not present in the withdrawal requests
     if (shouldFetchMaxBalances) {
-      const balances = await this.getBalances(
+      const balances = await this.getTokenBalancesInfo(
         tokenRequests.map(({ address }) => address)
       )
       tokenRequests = tokenRequests.map(({ amount, address }, i) => ({
@@ -1071,14 +1114,16 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
         paymasterServiceData: { mode: PaymasterMode.ERC20 }
       }
     )
-    return (feeQuotesResponse?.feeQuotes ?? []).map(
-      ({
-        maxGasFee: _,
-        maxGasFeeUSD: __,
-        validUntil: ___,
-        usdPayment: ____,
-        ...rest
-      }) => rest
+
+    return await Promise.all(
+      (feeQuotesResponse?.feeQuotes ?? []).map(async (quote) => ({
+        symbol: quote.symbol,
+        tokenAddress: quote.tokenAddress,
+        decimal: quote.decimal,
+        logoUrl: quote.logoUrl,
+        premiumPercentage: quote.premiumPercentage,
+        balance: await this.getTokenBalance(quote.tokenAddress as Hex)
+      }))
     )
   }
 

--- a/tests/paymaster/read.test.ts
+++ b/tests/paymaster/read.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../src/paymaster"
 import { getConfig } from "../utils"
 
-describe.skip("Paymaster: Read", () => {
+describe("Paymaster: Read", () => {
   const nftAddress = "0x1758f42Af7026fBbB559Dc60EcE0De3ef81f665e"
   const {
     chain,


### PR DESCRIPTION
# Summary

Added a fetch for token balance in getSupportedTokens method which is returning supported erc20 tokens for paymaster payments. This method output will now also contain token balance of the smart account.

Created a new method **getTokenBalance()** which is similar to **getTokenBalanceInfo()** (which has been renamed from **getBalance()**), the scope of this new method is to fetch only the token balance and nothing more.

## Change Type

- [ ] Bug Fix
- [ ] Refactor
- [x] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
