### PR TITLE
feat: signTypedData draft

### DIFF
--- a/src/account/BaseSmartContractAccount.ts
+++ b/src/account/BaseSmartContractAccount.ts
@@ -132,7 +132,7 @@ export abstract class BaseSmartContractAccount<
    * @param _params -- Typed Data params to sign
    */
   async signTypedData(_params: SignTypedDataParams): Promise<`0x${string}`> {
-    throw new Error("signTypedData not supported")
+    return this.signer.signTypedData(_params)
   }
 
   /**

--- a/src/account/utils/Utils.ts
+++ b/src/account/utils/Utils.ts
@@ -8,7 +8,7 @@ import {
   parseAbiParameters
 } from "viem"
 import type { UserOperationStruct } from "../../account"
-import { type SupportedSigner, convertSigner } from "../../account"
+import { type SupportedSigner, convertSigner, MAGIC_BYTES } from "../../account"
 import { extractChainIdFromBundlerUrl } from "../../bundler"
 import { extractChainIdFromPaymasterUrl } from "../../bundler"
 import type { BiconomySmartAccountV2Config } from "./Types.js"
@@ -156,7 +156,7 @@ export const wrapSignatureWith6492 = ({
       factoryCalldata,
       signature
     ]),
-    "0x6492649264926492649264926492649264926492649264926492649264926492"
+    MAGIC_BYTES
   ])
 }
 

--- a/tests/account/read.test.ts
+++ b/tests/account/read.test.ts
@@ -877,4 +877,55 @@ describe("Account:Read", () => {
       await expect(smartAccount.buildUserOp([tx1, tx2])).resolves.toBeTruthy()
     }
   )
+
+  test.concurrent(
+    "should sign typed data",
+    async () => {
+      const smartAccount = await createSmartAccountClient({
+        signer: walletClient,
+        bundlerUrl
+      })
+
+      const typedData = {
+        account: walletClient.account,
+        domain: {
+            name: "Ether Mail",
+            version: "1",
+            chainId: chain.id,
+            verifyingContract: smartAccountAddress
+        },
+        types: {
+            Person: [
+                { name: "name", type: "string" },
+                { name: "wallet", type: "address" }
+            ],
+            Mail: [
+                { name: "from", type: "Person" },
+                { name: "to", type: "Person" },
+                { name: "contents", type: "string" }
+            ]
+        },
+        primaryType: "Mail" as const,
+        message: {
+            from: {
+                name: "Cow",
+                wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+            },
+            to: {
+                name: "Bob",
+                wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+            },
+            contents: "Hello, Bob!"
+        }
+      }
+
+      const signature = await smartAccount.signTypedData(typedData)
+      const isVerified = await publicClient.verifyTypedData({
+        address: account.address,
+        signature,
+        ...typedData
+      })
+      expect(isVerified).toBeTruthy()
+    }
+  )
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to implement the `signTypedData` method in `BaseSmartContractAccount` and add `MAGIC_BYTES` constant in `Utils.ts`.

### Detailed summary
- Implemented `signTypedData` method in `BaseSmartContractAccount`
- Added `MAGIC_BYTES` constant in `Utils.ts`
- Added test for signing typed data in `read.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->