### PR TITLE
Fix broken doc links

### DIFF
--- a/src/account/BiconomySmartAccountV2.ts
+++ b/src/account/BiconomySmartAccountV2.ts
@@ -1185,7 +1185,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    * @returns Promise<UserOpResponse>
    * Sends a user operation
    *
-   * - Docs: https://docs.biconomy.io/Account/transactions/userpaid#send-useroperation
+   * - Docs: https://docs.biconomy.io/Account/methods#senduserop-
    *
    * @param userOp Partial<{@link UserOperationStruct}> the userOp params to be sent.
    * @param params {@link SendUserOpParams}.
@@ -1450,7 +1450,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
   /**
    * Sends a transaction (builds and sends a user op in sequence)
    *
-   * - Docs: https://docs.biconomy.io/Account/transactions/userpaid#send-transaction
+   * - Docs: https://docs.biconomy.io/Account/methods#sendtransaction-
    *
    * @param manyOrOneTransactions Array of {@link Transaction} to be batched and sent. Can also be a single {@link Transaction}.
    * @param buildUseropDto {@link BuildUserOpOptions}.
@@ -1539,7 +1539,7 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
    *
    * This method will also simulate the validation and execution of the user operation, telling the user if the user operation will be successful or not.
    *
-   * - Docs: https://docs.biconomy.io/Account/transactions/userpaid#build-useroperation
+   * - Docs: https://docs.biconomy.io/Account/methods#builduserop-
    *
    * @param transactions Array of {@link Transaction} to be sent.
    * @param buildUseropDto {@link BuildUserOpOptions}.


### PR DESCRIPTION
Before:
<img width="1302" alt="Screenshot 2024-06-28 at 16 22 44" src="https://github.com/bcnmy/biconomy-client-sdk/assets/4059136/607b586f-e8cc-4964-bd9d-acd52c255d10">

After:
<img width="1308" alt="Screenshot 2024-06-28 at 16 23 07" src="https://github.com/bcnmy/biconomy-client-sdk/assets/4059136/49369c07-e088-4e9a-992f-d5e3fda2285a">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates documentation links in `BiconomySmartAccountV2.ts` to point to the new methods section.

### Detailed summary
- Updated documentation links to point to the new methods section in BiconomySmartAccountV2.ts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->