### PR TITLE
feat: skip chain checks flag

### DIFF
--- a/src/account/BiconomySmartAccountV2.ts
+++ b/src/account/BiconomySmartAccountV2.ts
@@ -330,7 +330,10 @@ export class BiconomySmartAccountV2 extends BaseSmartContractAccount {
 
     // We check if chain ids match (skip this if chainId is passed by in the config)
     // This check is at the end of the function for cases when the signer is not passed in the config but a validation modules is and we get the signer from the validation module in this case
-    if (!biconomySmartAccountConfig.chainId) {
+    if (
+      biconomySmartAccountConfig.skipChainCheck !== true &&
+      !biconomySmartAccountConfig.chainId
+    ) {
       await compareChainIds(
         biconomySmartAccountConfig.signer || resolvedSmartAccountSigner,
         config,

--- a/src/account/utils/Types.ts
+++ b/src/account/utils/Types.ts
@@ -173,6 +173,8 @@ export type BiconomySmartAccountV2ConfigBaseProps = {
   initCode?: Hex
   /** Used for session key manager module */
   sessionData?: ModuleInfo
+  /** Used to skip the chain checks between singer, bundler and paymaster */
+  skipChainCheck?: boolean
 }
 export type BiconomySmartAccountV2Config =
   BiconomySmartAccountV2ConfigBaseProps &

--- a/tests/account/read.test.ts
+++ b/tests/account/read.test.ts
@@ -13,7 +13,7 @@ import {
   parseAbiParameters
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
-import { bsc } from "viem/chains"
+import { bsc, mainnet } from "viem/chains"
 import { beforeAll, describe, expect, test } from "vitest"
 import {
   type BiconomySmartAccountV2,
@@ -524,6 +524,56 @@ describe("Account:Read", () => {
   test.concurrent("should throw an error, chain id not found", async () => {
     const chainId = 0
     expect(() => getChain(chainId)).toThrow(ERROR_MESSAGES.CHAIN_NOT_FOUND)
+  })
+
+  test.concurrent(
+    "should skip chain check if skipChainCheck flag is passed",
+    async () => {
+      const walletClient = createWalletClient({
+        account,
+        chain: mainnet,
+        transport: http()
+      })
+      expect(
+        createSmartAccountClient({
+          signer: walletClient,
+          viemChain: mainnet,
+          skipChainCheck: true,
+          bundlerUrl,
+          paymasterUrl
+        })
+      ).resolves
+    }
+  )
+
+  test.concurrent("should throw error of incorrect chain setup", async () => {
+    const walletClient = createWalletClient({
+      account,
+      chain: mainnet,
+      transport: http()
+    })
+    await expect(
+      createSmartAccountClient({
+        signer: walletClient,
+        viemChain: mainnet,
+        skipChainCheck: false,
+        bundlerUrl,
+        paymasterUrl
+      })
+    ).rejects.toThrowError(
+      "Chain IDs from signer (1) and bundler (80002) do not match."
+    )
+
+    await expect(
+      createSmartAccountClient({
+        signer: walletClient,
+        viemChain: mainnet,
+        bundlerUrl,
+        paymasterUrl
+      })
+    ).rejects.toThrowError(
+      "Chain IDs from signer (1) and bundler (80002) do not match."
+    )
   })
 
   test.concurrent(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to introduce a new `skipChainCheck` flag in the `BiconomySmartAccountV2Config` to allow skipping chain checks between signer, bundler, and paymaster.

### Detailed summary
- Added `skipChainCheck` flag in `BiconomySmartAccountV2Config`
- Modified logic to skip chain checks based on the flag
- Updated tests to cover scenarios with `skipChainCheck` flag

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->