### PR TITLE
test: safe

### DIFF
--- a/tests/paymaster/write.test.ts
+++ b/tests/paymaster/write.test.ts
@@ -259,6 +259,40 @@ describe("Paymaster:Write", () => {
     )
   }, 60000)
 
+  test("should check sending txs with paymasterServiceData.smartAccountInfo set to SAFE", async () => {
+    await topUp(smartAccountAddress, BigInt(1000000000000000000))
+    const balanceOfRecipient = await checkBalance(recipient)
+
+    const { wait } = await smartAccount.sendTransaction(
+      {
+        to: recipient,
+        value: 1n
+      },
+      {
+        nonceOptions,
+        paymasterServiceData: {
+          mode: PaymasterMode.SPONSORED,
+          smartAccountInfo: {
+            name: "SAFE",
+            version: "1.4.1"
+          }
+        }
+      }
+    )
+
+    const {
+      receipt: { transactionHash },
+      success
+    } = await wait()
+
+    expect(success).toBe("true")
+
+    const newBalanceOfRecipient = await checkBalance(recipient)
+
+    expect(transactionHash).toBeTruthy()
+    expect(newBalanceOfRecipient - balanceOfRecipient).toBe(1n)
+  }, 60000)
+
   test("should withdraw all native token", async () => {
     await nonZeroBalance(smartAccountAddress)
     const balanceOfSABefore = await checkBalance(smartAccountAddress)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add a test for sending transactions with `paymasterServiceData.smartAccountInfo` set to SAFE.

### Detailed summary
- Added a test for sending transactions with `smartAccountInfo` set to SAFE
- Checked balance before and after transaction
- Verified transaction success and balance change

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->