### PR TITLE
fix: remove sign typed data

### DIFF
--- a/src/account/BaseSmartContractAccount.ts
+++ b/src/account/BaseSmartContractAccount.ts
@@ -158,6 +158,7 @@ export abstract class BaseSmartContractAccount<
    * @param params -- Typed Data params to sign
    */
   async signTypedDataWith6492(
+    // @ts-ignore
     params: SignTypedDataParams
   ): Promise<`0x${string}`> {
     throw new Error("signTypedDataWith6492 not supported")

--- a/src/account/BaseSmartContractAccount.ts
+++ b/src/account/BaseSmartContractAccount.ts
@@ -132,7 +132,7 @@ export abstract class BaseSmartContractAccount<
    * @param _params -- Typed Data params to sign
    */
   async signTypedData(_params: SignTypedDataParams): Promise<`0x${string}`> {
-    return this.signer.signTypedData(_params)
+    throw new Error("signTypedData not supported")
   }
 
   /**
@@ -160,12 +160,13 @@ export abstract class BaseSmartContractAccount<
   async signTypedDataWith6492(
     params: SignTypedDataParams
   ): Promise<`0x${string}`> {
-    const [isDeployed, signature] = await Promise.all([
-      this.isAccountDeployed(),
-      this.signTypedData(params)
-    ])
+    throw new Error("signTypedDataWith6492 not supported")
+    // const [isDeployed, signature] = await Promise.all([
+    //   this.isAccountDeployed(),
+    //   this.signTypedData(params)
+    // ])
 
-    return this.create6492Signature(isDeployed, signature)
+    // return this.create6492Signature(isDeployed, signature)
   }
 
   /**

--- a/src/account/utils/Types.ts
+++ b/src/account/utils/Types.ts
@@ -558,7 +558,7 @@ export interface ISmartContractAccount<
    * @param params - {@link SignTypedDataParams}
    * @returns the signed hash for the message passed
    */
-  signTypedData(params: SignTypedDataParams): Promise<Hash>;
+  // signTypedData(params: SignTypedDataParams): Promise<Hash>;
 
   /**
    * If the account is not deployed, it will sign the message and then wrap it in 6492 format
@@ -574,7 +574,7 @@ export interface ISmartContractAccount<
    * @param params - {@link SignTypedDataParams}
    * @returns the signed hash for the params passed in wrapped in 6492 format
    */
-  signTypedDataWith6492(params: SignTypedDataParams): Promise<Hash>;
+  // signTypedDataWith6492(params: SignTypedDataParams): Promise<Hash>;
 
   /**
    * @returns the address of the account

--- a/tests/account/read.test.ts
+++ b/tests/account/read.test.ts
@@ -967,12 +967,7 @@ describe("Account:Read", () => {
       }
     }
 
-    const signature = await smartAccount.signTypedData(typedData)
-    const isVerified = await publicClient.verifyTypedData({
-      address: account.address,
-      signature,
-      ...typedData
-    })
-    expect(isVerified).toBeTruthy()
+    const signature = smartAccount.signTypedData(typedData)
+    expect(signature).rejects.toThrowError("signTypedData not supported")
   })
 })


### PR DESCRIPTION
Removing signTypedData as Biconomy Smart Account V2 is not compatible with ERC 712. 
The assumption made at integration time of this feature was incorrect and can be confusing if not removed.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the codebase to remove the functionality of signing typed data in smart accounts and adds error handling for unsupported operations.

### Detailed summary
- Removed signing typed data functionality in smart accounts
- Added error handling for unsupported signTypedData operations
- Updated test cases to reflect changes in signing typed data operations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->