### PR TITLE
chore: get signer address

### DIFF
--- a/src/account/utils/convertSigner.ts
+++ b/src/account/utils/convertSigner.ts
@@ -110,7 +110,7 @@ export const convertSigner = async (
 */
 export const getSignerAddress = async (signer: SupportedSigner): Promise<Hex> => {
   if (isEthersSigner(signer)) {
-    const result = await (signer as Signer).getAddress();
+    const result = await (signer as Signer)?.getAddress();
     if (result) return result as Hex
     throw new Error("Unsupported signer");
   } if (isWalletClient(signer)) {

--- a/src/account/utils/convertSigner.ts
+++ b/src/account/utils/convertSigner.ts
@@ -1,11 +1,12 @@
 import {
   http,
+  type Hex,
   type PrivateKeyAccount,
   type WalletClient,
   createWalletClient
 } from "viem"
 import { WalletClientSigner } from "../../account"
-import type { Signer, SmartAccountSigner, SupportedSigner } from "../../account"
+import type { LightSigner, Signer, SmartAccountSigner, SupportedSigner } from "../../account"
 import { EthersSigner } from "./EthersSigner.js"
 
 interface SmartAccountResult {
@@ -100,4 +101,30 @@ export const convertSigner = async (
     resolvedSmartAccountSigner = signer as SmartAccountSigner
   }
   return { signer: resolvedSmartAccountSigner, rpcUrl, chainId }
+}
+/*
+  This function is used to get the signer's address, it can be used to get the signer's address from different types of signers.
+  The function takes a signer as an argument and returns the signer's address.
+  The function checks the type of the signer and returns the signer's address based on the type of the signer.
+  The function throws an error if the signer is not supported.
+*/
+export const getSignerAddress = async (signer: SupportedSigner): Promise<Hex> => {
+  if (isEthersSigner(signer)) {
+    const result = await (signer as Signer).getAddress();
+    if (result) return result as Hex
+    throw new Error("Unsupported signer");
+  } if (isWalletClient(signer)) {
+    const result = ((signer as WalletClient)?.account?.address);
+    if (result) return result as Hex
+    throw new Error("Unsupported signer");
+  } if (isPrivateKeyAccount(signer)) {
+    const result = ((signer as PrivateKeyAccount)?.address);
+    if (result) return result as Hex
+    throw new Error("Unsupported signer");
+  } if (isAlchemySigner(signer)) {
+    const result = ((signer as SmartAccountSigner)?.inner?.address);
+    if (result) return result as Hex
+    throw new Error("Unsupported signer");
+  }
+  throw new Error("Unsupported signer");
 }

--- a/src/account/utils/convertSigner.ts
+++ b/src/account/utils/convertSigner.ts
@@ -6,7 +6,7 @@ import {
   createWalletClient
 } from "viem"
 import { WalletClientSigner } from "../../account"
-import type { LightSigner, Signer, SmartAccountSigner, SupportedSigner } from "../../account"
+import type { Signer, SmartAccountSigner, SupportedSigner } from "../../account"
 import { EthersSigner } from "./EthersSigner.js"
 
 interface SmartAccountResult {


### PR DESCRIPTION
Requested by Venky, so that users can accommodate a custom signer in `useAA`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function `getSignerAddress` to `convertSigner.ts` for retrieving signer addresses based on signer types.

### Detailed summary
- Added `getSignerAddress` function to retrieve signer addresses
- Supports different signer types: Ethers, WalletClient, PrivateKeyAccount, AlchemySigner

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->