### PR TITLE
fix: update parsing of the bundler url from config

### DIFF
--- a/src/bundler/utils/Utils.ts
+++ b/src/bundler/utils/Utils.ts
@@ -2,7 +2,7 @@ import { toHex } from "viem"
 
 export const extractChainIdFromBundlerUrl = (url: string): number => {
   try {
-    const regex = /\/api\/v2\/(\d+)\/[a-zA-Z0-9.-]+$/
+    const regex = /\/api\/v[2-3]\/(\d+)\/[a-zA-Z0-9.-]+$/
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     const match = regex.exec(url)!
     return Number.parseInt(match[1])


### PR DESCRIPTION
Our SDK was hard coded to expect a v2 URL version.

This PR aims to allow upcoming v3 version for Nexus

