### PR TITLE
remove frozen lockfile

### DIFF
--- a/tests/src/executables.ts
+++ b/tests/src/executables.ts
@@ -3,7 +3,7 @@ import { execa } from "execa"
 const cwd = "./node_modules/nexus"
 
 export const init = async () =>
-  await execa({ cwd })`yarn install --frozen-lockfile`
+  await execa({ cwd })`yarn install`
 
 export const cleanOne = async (rpcPort: number) =>
   await execa({ cwd })`rm -rf ./deployments/anvil-${rpcPort}`


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `init` function to remove the `--frozen-lockfile` flag from the `yarn install` command and updates the `cleanOne` function to remove a specific directory based on the `rpcPort`.

### Detailed summary
- Removed `--frozen-lockfile` flag from `yarn install` in `init` function
- Updated `cleanOne` function to remove a specific directory based on `rpcPort`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->