### PR TITLE
fix: extract chain id using URL path instead of regex

### DIFF
--- a/src/bundler/utils/Utils.ts
+++ b/src/bundler/utils/Utils.ts
@@ -1,23 +1,21 @@
-export const extractChainIdFromBundlerUrl = (url: string): number => {
+export const extractChainIdFromUrl = (url: string) => {
   try {
-    const regex = /\/api\/v2\/(\d+)\/[a-zA-Z0-9.-]+$/
-    // biome-ignore lint/style/noNonNullAssertion: <explanation>
-    const match = regex.exec(url)!
-    return Number.parseInt(match[1])
-  } catch (error) {
-    throw new Error("Invalid chain id")
-  }
-}
+    const pathSegments = new URL(url).pathname.split("/");
+    const chainId = pathSegments[3];
+    const chainIdNumber = Number.parseInt(chainId);
 
-export const extractChainIdFromPaymasterUrl = (url: string): number => {
-  try {
-    const regex = /\/api\/v\d+\/(\d+)\//
-    const match = regex.exec(url)
-    if (!match) {
-      throw new Error("Invalid URL format")
+    if (!chainId || isNaN(chainIdNumber)) {
+      throw new Error();
     }
-    return Number.parseInt(match[1])
-  } catch (error) {
-    throw new Error("Invalid chain id")
+
+    return chainIdNumber;
+  } catch {
+    throw new Error("Invalid chain id");
   }
-}
+};
+
+export const extractChainIdFromBundlerUrl = (url: string): number =>
+  extractChainIdFromUrl(url);
+
+export const extractChainIdFromPaymasterUrl = (url: string): number =>
+  extractChainIdFromUrl(url);


### PR DESCRIPTION
Hi on behalf of the [Unhosted](https://unhosted.com/) team! We're building our wallet and services on top of this SDK. 
We have contacted your support on Telegram and were advised not to expose the bundlerUrl and paymasterUrl in our client-side application (a chrome-extension wallet like metamask), so our solution is to proxy bundler and paymaster calls through our own backend.

This PR will allow us to keep your SDK compatible with our backend service (and any other team that has this same use case). We can't use the same URL pattern that your regex is checking, as we're handling versioning in a different way (through headers).

In short, we want to be able to instantiate the smartAccount like this:

```
const biconomySmartAccountConfig: BiconomySmartAccountV2Config = {
        signer: signer,
        bundlerUrl: `https://our-backend.com/aa/bundler/${chainId}`,
        paymasterUrl: `https://our-backend.com/aa/paymaster/${chainId}`,
      };
``` 

Above will not work unless the changes proposed in this PR are accepted, as our bundler and paymaster wrapper url don't follow the specified regex.

Thank you.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `extractChainIdFromUrl` function in `src/bundler/utils/Utils.ts` to simplify its implementation and improve error handling. It also updates related functions to use the new extraction logic.

### Detailed summary
- Replaced regex-based extraction with URL pathname splitting in `extractChainIdFromUrl`.
- Improved error handling for invalid chain IDs.
- Updated `extractChainIdFromBundlerUrl` and `extractChainIdFromPaymasterUrl` to call `extractChainIdFromUrl`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->